### PR TITLE
Increase FastCGI timeout

### DIFF
--- a/tests/build/travis-ci-apache
+++ b/tests/build/travis-ci-apache
@@ -16,7 +16,7 @@
     AddHandler php5-fcgi .php
     Action php5-fcgi /php5-fcgi
     Alias /php5-fcgi /usr/lib/cgi-bin/php5-fcgi
-    FastCgiExternalServer /usr/lib/cgi-bin/php5-fcgi -host 127.0.0.1:9000 -pass-header Authorization
+    FastCgiExternalServer /usr/lib/cgi-bin/php5-fcgi -host 127.0.0.1:9000 -pass-header Authorization -idle-timeout 60
   </IfModule>
 
 </VirtualHost>


### PR DESCRIPTION
Currently one of the Behat features fails as it takes ~50 seconds to run, causing a timeout. The real solution would be speed it up/delegate the work to a queue, but in the meantime...
