### PR TITLE
Test newer PHPs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: php
 
 php:
   - 5.5
+  - 5.6
+  - 7.0
+
+matrix:
+  allow_failures:
+        - php: 7.0
 
 mysql:
   database: elife_profile
@@ -19,6 +25,7 @@ install:
   - sudo apt-get install apache2 libapache2-mod-fastcgi
   - sudo a2enmod rewrite actions fastcgi alias
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
+  - if [[ -f ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/www.conf.default ]] ; then sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/www.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/www.conf ; fi
   - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
 


### PR DESCRIPTION
In an ideal world we'll keep up to date with the latest PHP versions, in reality we may not be upgrade immediately so we should test any future versions, including unrealised versions. This should make sure that we're writing forwards-compatible code.

I've also added PHP7, but as it isn't finalised it should be allowed to fail (plus some contrib code might not be compatible either).
