### PR TITLE
Use correct status code

### DIFF
--- a/src/elife_profile/modules/custom/elife_services/resources/article.inc
+++ b/src/elife_profile/modules/custom/elife_services/resources/article.inc
@@ -413,7 +413,7 @@ function _elife_services_article_update_values($article_version, $data, $new = F
   }
 
   if (!empty($required)) {
-    return services_error(t('No value provided for required: @fields.', array('@fields' => implode(', ', $required))), 406);
+    return services_error(t('No value provided for required: @fields.', array('@fields' => implode(', ', $required))), 400);
   }
 
   // This ensures that paths will not be automatically generated.
@@ -425,13 +425,13 @@ function _elife_services_article_update_values($article_version, $data, $new = F
   // Set the article-version-id if article is new.
   if ($new && !empty($data['article-version-id'])) {
     if (!ElifeArticleVersion::uniqueArticleVersionId($data['article-version-id'])) {
-      return services_error(t('Invalid value provided: @field.', array('@field' => 'Article version id (must be unique)')), 406);
+      return services_error(t('Invalid value provided: @field.', array('@field' => 'Article version id (must be unique)')), 400);
     }
   }
 
   if (isset($data['doi'])) {
     if (!ElifeArticleVersion::validateDoi($data['doi'])) {
-      return services_error(t('Invalid value provided: @field.', array('@field' => 'doi')), 406);
+      return services_error(t('Invalid value provided: @field.', array('@field' => 'doi')), 400);
     }
   }
 
@@ -659,7 +659,7 @@ function _elife_services_article_update_values($article_version, $data, $new = F
     // Check to see that path is unique.
     if ($new && $path = path_load(array('alias' => $data['path']))) {
       if ($path['source'] != $source) {
-        return services_error(t('Path is already in use: @path.', array('@path' => $data['path'])), 406);
+        return services_error(t('Path is already in use: @path.', array('@path' => $data['path'])), 400);
       }
     }
 
@@ -1187,7 +1187,7 @@ function _elife_services_article_fragment_update_values($data, $type, $subarticl
   }
 
   if (!empty($required)) {
-    return services_error(t('No value provided for required: @fields.', array('@fields' => implode(', ', $required))), 406);
+    return services_error(t('No value provided for required: @fields.', array('@fields' => implode(', ', $required))), 400);
   }
 
   $child = NULL;
@@ -1234,7 +1234,7 @@ function _elife_services_article_fragment_update_values($data, $type, $subarticl
 
   if (isset($data['doi'])) {
     if (!ElifeArticleVersion::validateDoi($data['doi'])) {
-      return services_error(t('Invalid value provided: @field.', array('@field' => 'doi')), 406);
+      return services_error(t('Invalid value provided: @field.', array('@field' => 'doi')), 400);
     }
 
     $ewrapper->field_elife_a_doi->set($data['doi']);
@@ -1282,7 +1282,7 @@ function _elife_services_article_fragment_update_values($data, $type, $subarticl
     // Check to see that path is unique.
     if ($new && $path = path_load(array('alias' => $data['path']))) {
       if ($path['source'] != $source) {
-        return services_error(t('Path is already in use: @path.', array('@path' => $data['path'])), 406);
+        return services_error(t('Path is already in use: @path.', array('@path' => $data['path'])), 400);
       }
     }
 

--- a/tests/behat/features/article_resource_GPoPuDel.feature
+++ b/tests/behat/features/article_resource_GPoPuDel.feature
@@ -35,7 +35,7 @@ Feature: Article Resource - GetPostPutDelete requests (API)
           "status": "VOR"
         }
       """
-    And the response code should be 406
+    And the response code should be 400
     And I send a PUT request to "api/article/05227.1.json" with body:
     """
         {

--- a/tests/behat/features/article_resource_getpost.feature
+++ b/tests/behat/features/article_resource_getpost.feature
@@ -36,4 +36,4 @@ Feature: Article Resource - GetPost requests (API)
           "status": "VOR"
         }
       """
-    And the response code should be 406
+    And the response code should be 400

--- a/tests/behat/features/article_resource_post.feature
+++ b/tests/behat/features/article_resource_post.feature
@@ -41,7 +41,7 @@ Feature: Article Resource - POST (API)
           "status": "VOR"
         }
       """
-    Then response code should be 406
+    Then response code should be 400
     And response should contain "Invalid value provided: doi."
 
     Examples:
@@ -73,7 +73,7 @@ Feature: Article Resource - POST (API)
           "status": "VOR"
         }
       """
-    Then response code should be 406
+    Then response code should be 400
     And response should contain "Invalid value provided: Article version id (must be unique)."
 
   Scenario Outline: Attempt to post an article without all required fields
@@ -84,7 +84,7 @@ Feature: Article Resource - POST (API)
           <required_data>
         }
       """
-    Then response code should be 406
+    Then response code should be 400
     And response should contain "No value provided for required: <field_errors>."
 
     Examples:


### PR DESCRIPTION
![](http://httpstatusdogs.com/wp-content/uploads/2011/12/406.jpg)

The `406 Not Acceptable` HTTP status code means that that request's Accept header can't be matched, not that the contents are semantically correct. The original HTTP spec doesn't provide anything more specific than `400 Bad Request` for this case; some use the `422 Unprocessable Entity` introduced by WebDAV (so a `400 Bad Request` would just refer to invalid JSON), which I don't mind using instead (but ultimately doesn't really make a difference).
