### PR TITLE
Don't recursively use Drush Make

### DIFF
--- a/remake.sh
+++ b/remake.sh
@@ -6,6 +6,6 @@ cd "$SCRIPTPATH"
 rm -rf ./src/elife_profile/libraries/
 rm -rf ./src/elife_profile/modules/contrib/
 rm -rf ./src/elife_profile/themes/contrib/
-drush make --no-core --concurrency=3 --contrib-destination=. ./src/elife_profile/elife_profile.make.yml ./src/elife_profile
+drush make --no-core --concurrency=3 --no-recursion --contrib-destination=. ./src/elife_profile/elife_profile.make.yml ./src/elife_profile
 npm install --prefix ./src/elife_profile/libraries/elife-eif-schema/
 composer install --no-interaction --working-dir=./src


### PR DESCRIPTION
As we're defining all Drush Make dependencies, this stops it from resolving recursive dependencies (eg spyc in the services module) twice.
