### PR TITLE
Prevent unset variable warning

### DIFF
--- a/src/elife_profile/modules/custom/elife_templates/templates/views-view-unformatted.tpl.php
+++ b/src/elife_profile/modules/custom/elife_templates/templates/views-view-unformatted.tpl.php
@@ -11,7 +11,7 @@
 <?php foreach ($rows as $id => $row): ?>
   <div<?php print ($classes_array[$id]) ? ' class="' . $classes_array[$id] .'"' : ''; ?>>
     <?php print $row; ?>
-    <?php if ($contextual_node): ?>
+    <?php if (!empty($contextual_node)): ?>
       <?php print $contextual_node[$id]; ?>
     <?php endif; ?>
   </div>


### PR DESCRIPTION
The `$contextual_node` variable may not have been set, so currently a PHP warning is emitted.
