### PR TITLE
Cater for elements not existing

### DIFF
--- a/tests/behat/features/bootstrap/Page/Element/CiviCrmSignupForm.php
+++ b/tests/behat/features/bootstrap/Page/Element/CiviCrmSignupForm.php
@@ -18,6 +18,9 @@ class CiviCrmSignupForm extends Element {
   public function hasId($id)
   {
     $element = $this->find("css", 'input[name=custom_6]');
+    if(!$element) {
+      throw $this->elementNotFound('input', 'css', 'input[name=custom_6]');
+    }
     $id_current = $element->getAttribute('value');
     if ($id !== $id_current) {
       throw new Exception('Expected value ' . $id . ' but found ' . $id_current);

--- a/tests/behat/features/bootstrap/Page/Element/ContentAlertsSignupForm.php
+++ b/tests/behat/features/bootstrap/Page/Element/ContentAlertsSignupForm.php
@@ -18,6 +18,9 @@ class ContentAlertsSignupForm extends Element {
   public function hasId($id)
   {
     $element = $this->find("css", 'input[name=custom_6]');
+    if(!$element) {
+      throw $this->elementNotFound('input', 'css', 'input[name=custom_6]');
+    }
     $id_current = $element->getAttribute('value');
     if ($id !== $id_current) {
       throw new Exception('Expected value ' . $id . ' but found ' . $id_current);


### PR DESCRIPTION
Currently there isn't a check to make sure that the element has been found, leading to a fatal error.
