### PR TITLE
Don't allow modules to be added/updated through the UI

### DIFF
--- a/src/settings.php
+++ b/src/settings.php
@@ -6,6 +6,9 @@ $conf['composer_manager_file_dir'] = __DIR__;
 $conf['composer_manager_autobuild_file'] = FALSE;
 $conf['composer_manager_autobuild_packages'] = FALSE;
 
+// Don't allow modules to be added/updated through the UI.
+$conf['allow_authorize_operations'] = FALSE;
+
 // Include the local settings, this MUST contain the $databases variable (and
 // any other sensitive credentials in the future), as well as any custom
 // configuration required during development.


### PR DESCRIPTION
Since we're using Drush Make people shouldn't be allowed to add/modules through the UI.
