### PR TITLE
Disable menu options for article/term asset nodes

### DIFF
--- a/src/elife_profile/modules/custom/elife_article_assets/elife_article_assets.strongarm.inc
+++ b/src/elife_profile/modules/custom/elife_article_assets/elife_article_assets.strongarm.inc
@@ -43,9 +43,7 @@ function elife_article_assets_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'menu_options_elife_article_assets';
-  $strongarm->value = array(
-    0 => 'main-menu',
-  );
+  $strongarm->value = array();
   $export['menu_options_elife_article_assets'] = $strongarm;
 
   $strongarm = new stdClass();

--- a/src/elife_profile/modules/custom/elife_term_assets/elife_term_assets.strongarm.inc
+++ b/src/elife_profile/modules/custom/elife_term_assets/elife_term_assets.strongarm.inc
@@ -43,9 +43,7 @@ function elife_term_assets_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'menu_options_elife_term_assets';
-  $strongarm->value = array(
-    0 => 'main-menu',
-  );
+  $strongarm->value = array();
   $export['menu_options_elife_term_assets'] = $strongarm;
 
   $strongarm = new stdClass();


### PR DESCRIPTION
Currently the article/term asset nodes have an option to add it to the main menu. This removes it.
