### PR TITLE
Add PHP_CodeSniffer configuration

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+
+<ruleset name="eLife">
+
+    <file>./src</file>
+
+    <exclude-pattern>./src/elife_profile/libraries/*</exclude-pattern>
+    <exclude-pattern>./src/elife_profile/modules/contrib/*</exclude-pattern>
+    <exclude-pattern>./src/elife_profile/themes/contrib/*</exclude-pattern>
+    <exclude-pattern>./src/elife_profile/themes/custom/elife/*</exclude-pattern>
+    <exclude-pattern>./src/elife_profile/themes/custom/elife_newlook/*</exclude-pattern>
+    <exclude-pattern>./src/vendor/*</exclude-pattern>
+
+    <arg name="extensions" value="php,module,inc,install,test,profile,theme,js,css,info,txt"/>
+    <arg name="report" value="summary"/>
+    <arg value="np"/>
+
+    <rule ref="Drupal"/>
+
+</ruleset>


### PR DESCRIPTION
This adds PHP_CodeSniffer configuration.

I've excluded the two existing themes and these are the parts copied from the old site, and we will replace in the future (and do contain some non-eLife code). But it might still be worth including them.
