### PR TITLE
Fix double base path on the cover

### DIFF
--- a/src/elife_profile/modules/custom/elife_article/src/ElifeArticleVersion.php
+++ b/src/elife_profile/modules/custom/elife_article/src/ElifeArticleVersion.php
@@ -1099,7 +1099,7 @@ class ElifeArticleVersion {
       if (!$section_code) {
         $section_code = 'other';
       }
-      $reference_path = url($reference);
+      $reference_path = url($reference, ['absolute' => TRUE]);
     }
     else {
       if ($article = self::getArticle($reference)) {
@@ -1114,7 +1114,7 @@ class ElifeArticleVersion {
             $section_code = $key;
           }
         }
-        $reference_path = url('node/' . $article_version->nid->value());
+        $reference_path = drupal_get_path_alias('node/' . $article_version->nid->value());
       }
     }
     if ($reference_path) {

--- a/tests/behat/features/front_matter.feature
+++ b/tests/behat/features/front_matter.feature
@@ -34,6 +34,17 @@ Feature: Front Matter
     And I should see "VOR 05224 v1" in the "h1" element
 
   @api
+  Scenario: Load cover item to homepage referencing a URL
+    Given "elife_cover" content:
+      | title | field_elife_fm_reference | field_elife_fm_reference_type |
+      | Podcast 1 | podcast/1 | Url |
+    And I add "elife_cover" with title "Podcast 1" to entityqueue "elife_cover"
+    When I am on the homepage
+    Then I should see the text "Podcast 1" in the "front_matter_cover" region
+    And I follow "Podcast 1" in the "front_matter_cover" region
+    And I should be on "podcast/1"
+
+  @api
   Scenario: Load front matter items to homepage
     Given I set header "Content-Type" with value "application/json"
     And I send a POST request to "api/article.json" with body:


### PR DESCRIPTION
If the site's deployed in a subdirectory (eg http://localhost/foo/) links to the cover items end up with double base paths (eg http://localhost/foo/foo/whatever). This changes `ElifeArticleVersion::getSection()` so that `$references` can be safely passed into `url()`.
