### PR TITLE
Use Composer rather than X Autoload

### DIFF
--- a/src/elife_profile/elife_profile.info
+++ b/src/elife_profile/elife_profile.info
@@ -72,7 +72,6 @@ dependencies[] = xmlsitemap
 dependencies[] = strongarm
 dependencies[] = services
 dependencies[] = rest_server
-dependencies[] = xautoload
 dependencies[] = field_collection
 dependencies[] = panels
 dependencies[] = semanticviews

--- a/src/elife_profile/elife_profile.make.yml
+++ b/src/elife_profile/elife_profile.make.yml
@@ -155,10 +155,6 @@ projects:
     version: '1.2'
   webform:
     version: '4.9'
-  xautoload:
-    version: '5.1'
-    patch:
-      - 'https://www.drupal.org/files/issues/xautoload-base_table_or_view_not-2393205-16.patch'
   xmlsitemap:
     version: '2.2'
 

--- a/src/elife_profile/modules/custom/elife_article/composer.json
+++ b/src/elife_profile/modules/custom/elife_article/composer.json
@@ -9,7 +9,8 @@
             "eLife\\": [
                 "domain/src/eLife/",
                 "infrastructure/src/eLife/"
-            ]
+            ],
+            "Drupal\\elife_article\\": "src/"
         }
     }
 }

--- a/src/elife_profile/modules/custom/elife_article/elife_article.info
+++ b/src/elife_profile/modules/custom/elife_article/elife_article.info
@@ -21,7 +21,6 @@ dependencies[] = taxonomy
 dependencies[] = text
 dependencies[] = views
 dependencies[] = views_bulk_operations
-dependencies[] = xautoload
 features[ctools][] = strongarm:strongarm:1
 features[ctools][] = views:views_default:3.0
 features[features_api][] = api:2

--- a/src/elife_profile/modules/custom/elife_services/elife_services.info
+++ b/src/elife_profile/modules/custom/elife_services/elife_services.info
@@ -2,7 +2,6 @@ name = eLife: Services
 description = A collection of resources for eLife Services
 dependencies[] = services
 dependencies[] = elife_article
-dependencies[] = xautoload
 package = eLife
 core = 7.x
 files[] = includes/services.inc


### PR DESCRIPTION
We don't need the X Autoload module if we're using [Composer globally](https://github.com/elifesciences/elife-drupal-ingest/pull/52).

This does mean we have to define any paths in `composer.json` files rather than relying on files being inside `src` folders.
