### PR TITLE
Make sure invalid JSON message appears correctly

### DIFF
--- a/src/elife_profile/elife_profile.make.yml
+++ b/src/elife_profile/elife_profile.make.yml
@@ -175,7 +175,7 @@ libraries:
     download:
       type: 'git'
       url: 'ssh://git@github.com/elifesciences/elife-eif-schema.git'
-      revision: 'fcd852df4d818b0acca5fd1bf2ac35cd9ab3d5cc'
+      revision: '16627ce6549135e366404ceae1adcd93016f2c02'
   cluetip:
     download:
       type: 'git'

--- a/tests/behat/features/article_resource_post.feature
+++ b/tests/behat/features/article_resource_post.feature
@@ -156,3 +156,21 @@ Feature: Article Resource - POST (API)
           "title": "Updated VOR 05227"
         }
       """
+
+  Scenario: Post an article with invalid JSON
+    Given I set header "Content-Type" with value "application/json"
+    And I send a POST request to "api/article.json" with body:
+      """
+        foo
+      """
+    And the response code should be 400
+    And the response should contain json:
+      """
+        [
+          {
+            "field": "data",
+            "message": "invalid JSON",
+            "value": "foo"
+          }
+        ]
+      """


### PR DESCRIPTION
Currently the invalid JSON message received back from the Node validator isn't actually JSON (see https://github.com/elifesciences/elife-eif-schema/pull/9), so an empty response body is returned. This corrects it.
