### PR TITLE
Work around the Composer Merge Plugin updating our dependencies

### DIFF
--- a/remake.sh
+++ b/remake.sh
@@ -8,4 +8,8 @@ rm -rf ./src/elife_profile/modules/contrib/
 rm -rf ./src/elife_profile/themes/contrib/
 drush make --no-core --concurrency=3 --no-recursion --contrib-destination=. ./src/elife_profile/elife_profile.make.yml ./src/elife_profile
 npm install --prefix ./src/elife_profile/libraries/elife-eif-schema/
+# See https://github.com/wikimedia/composer-merge-plugin/issues/34#issuecomment-126305530 re the below
+cp composer.lock composer.lock.orig
+composer install --no-interaction
+mv composer.lock.orig composer.lock
 composer install --no-interaction


### PR DESCRIPTION
See https://github.com/wikimedia/composer-merge-plugin/issues/34#issuecomment-126305530. It turns out that the Composer Merge Plugin runs `composer update` after the first `composer install`, so Travis runs etc use versions of dependencies that we don't expect. This works around it by doing a second `composer install` that forces Composer to revert them back to what we asked for in the first place.
