### PR TITLE
Allow the JMS Serializer to cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /bin/
+/cache/
 /local.settings.php
 /src/elife_profile/libraries/
 /src/elife_profile/modules/contrib/

--- a/src/elife_profile/modules/custom/elife_article/elife_article.module
+++ b/src/elife_profile/modules/custom/elife_article/elife_article.module
@@ -105,6 +105,8 @@ function elife_article_serializer() {
       ->configureListeners(function (EventDispatcher $dispatcher) {
         $dispatcher->addSubscriber(new SubArticleSubscriber());
       })
+      ->setCacheDir(variable_get('elife_cache_dir', sys_get_temp_dir()) . '/jms_serializer')
+      ->setDebug(!variable_get('elife_production', FALSE))
       ->build();
   }
 

--- a/src/settings.php
+++ b/src/settings.php
@@ -4,6 +4,9 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 $conf['elife_composer_vendor_path'] = __DIR__ . '/../vendor';
 
+// Define the environment.
+$conf['elife_production'] = FALSE;
+
 // Don't allow modules to be added/updated through the UI.
 $conf['allow_authorize_operations'] = FALSE;
 
@@ -22,6 +25,9 @@ $conf['pathologic_local_paths'] = [
   'https://www.elifesciences.org',
   '/',
 ];
+
+// File cache directory.
+$conf['elife_cache_dir'] = __DIR__ . '/../cache';
 
 // Include the local settings, this MUST contain the $databases variable (and
 // any other sensitive credentials in the future), as well as any custom


### PR DESCRIPTION
This should improve performance, rather than reparsing the annotations every time.
