### PR TITLE
Fix a 404 on requests where Cluetip isn't used

### DIFF
--- a/src/elife_profile/elife_profile.make.yml
+++ b/src/elife_profile/elife_profile.make.yml
@@ -16,6 +16,8 @@ projects:
       type: 'git'
       url: 'http://git.drupal.org/project/cluetip.git'
       revision: '6fe2bf6058a7899cfbc34050a7db56dff77a2a34'
+    patch:
+      - 'https://www.drupal.org/files/issues/cluetip-not-found-2248861-5.patch'
   context:
     version: '3.6'
   ctools:


### PR DESCRIPTION
Currently there's a broken request to the Cluetip JS library on every page where it isn't used, this fixes it.
