### PR TITLE
[WIP] Reset static cache on test runs

### DIFF
--- a/tests/behat/features/bootstrap/FeatureContext.php
+++ b/tests/behat/features/bootstrap/FeatureContext.php
@@ -50,6 +50,13 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
   }
 
   /**
+   * @AfterScenario
+   */
+  public function resetStaticCaches() {
+    drupal_static_reset();
+  }
+
+  /**
    * @BeforeScenario
    */
   public function resetFollowingRedirects() {


### PR DESCRIPTION
The problems on Travis runs _might_ be caused by Drupal's static cache not being reset after each scenario. If this is successful, it's a change that should be made upstream.
