### PR TITLE
Run tests in isolation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,10 +80,12 @@ install:
   - if [[ ! -e "$HOME/custom/selenium-server-standalone-2.44.0.jar" ]]; then wget --directory-prefix="$HOME/custom" http://selenium-release.storage.googleapis.com/2.44/selenium-server-standalone-2.44.0.jar; fi;
   - java -jar $HOME/custom/selenium-server-standalone-2.44.0.jar -p 4444 > /dev/null 2>&1 &
 
-  # Install site
+  # Populate the local settings file
   - cp ./tests/build/travis.local.settings.php ./local.settings.php
   - sed -i -e "s?%NODE_BIN%?$(which node)?g" ./local.settings.php
-  - ./install.sh
+
+  # Configure Behat
+  - cp ./tests/build/travis.behat.yml ./tests/behat/behat.yml
 
 script:
   - ./run-tests.sh

--- a/composer.lock
+++ b/composer.lock
@@ -1207,6 +1207,57 @@
             "time": "2015-06-01 17:42:31"
         },
         {
+            "name": "elife/isolated-drupal-behat-extension",
+            "version": "0.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/elifesciences/isolated-drupal-behat-extension.git",
+                "reference": "77ec452867db77744be1f4d77e066c007dba9ded"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/elifesciences/isolated-drupal-behat-extension/zipball/77ec452867db77744be1f4d77e066c007dba9ded",
+                "reference": "77ec452867db77744be1f4d77e066c007dba9ded",
+                "shasum": ""
+            },
+            "require": {
+                "behat/behat": "^3.0.6",
+                "behat/mink-extension": "~2.0",
+                "drupal/drupal-extension": "~3.0",
+                "php": ">=5.4",
+                "symfony/dependency-injection": "~2.5",
+                "symfony/event-dispatcher": "~2.3",
+                "symfony/filesystem": "~2.3",
+                "symfony/process": "~2.3"
+            },
+            "require-dev": {
+                "behat/mink-goutte-driver": "~1.0",
+                "drush/drush": "~7.0",
+                "mikey179/vfsstream": "~1.2",
+                "phpunit/phpunit": "~4.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "eLife\\IsolatedDrupalBehatExtension\\": [
+                        "./src"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "Extension for Behat that tests Drupal sites in isolation",
+            "homepage": "https://github.com/elifesciences/isolated-drupal-behat-extension",
+            "time": "2015-08-14 15:50:27"
+        },
+        {
             "name": "fabpot/goutte",
             "version": "v2.0.4",
             "source": {
@@ -3031,7 +3082,8 @@
         "symfony/process": 0,
         "sensiolabs/behat-page-object-extension": 20,
         "behat/drupal-propeople-context": 0,
-        "behat/web-api-extension": 20
+        "behat/web-api-extension": 20,
+        "elife/isolated-drupal-behat-extension": 0
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/tests/behat/behat.yml.dist
+++ b/tests/behat/behat.yml.dist
@@ -4,12 +4,15 @@ default:
       contexts:
         - FeatureContext: ~
         - ContentAlertsContext: ~
-        - Behat\Drupal\Propeople\PropeopleContext: ~
+        - IsolatedDrupalContext: ~
+        - IsolatedPropeopleContext: ~
         - Drupal\DrupalExtension\Context\MinkContext: ~
         - Drupal\DrupalExtension\Context\MessageContext: ~
-        - Drupal\DrupalExtension\Context\DrupalContext: ~
         - Behat\WebApiExtension\Context\WebApiContext: ~
   extensions:
+    eLife\IsolatedDrupalBehatExtension:
+      profile: 'elife_profile'
+      settings_file: '%paths.base%/../../src/settings.php'
     SensioLabs\Behat\PageObjectExtension:
     Behat\WebApiExtension:
       base_url: 'http://127.0.0.1:80'
@@ -21,7 +24,7 @@ default:
       blackbox: ~
       api_driver: 'drupal'
       drush:
-        alias: 'local'
+        root: '%paths.base%/../../web'
       region_map:
         footer: '#section-footer'
         front_matter: 'ol.frontmatter'

--- a/tests/behat/composer.json
+++ b/tests/behat/composer.json
@@ -2,6 +2,7 @@
   "require-dev": {
     "sensiolabs/behat-page-object-extension": "~2.0@dev",
     "behat/drupal-propeople-context": "~1.2",
-    "behat/web-api-extension": "~1.0@dev"
+    "behat/web-api-extension": "~1.0@dev",
+    "elife/isolated-drupal-behat-extension": "~0.1"
   }
 }

--- a/tests/behat/features/bootstrap/IsolatedDrupalContext.php
+++ b/tests/behat/features/bootstrap/IsolatedDrupalContext.php
@@ -1,0 +1,29 @@
+<?php
+
+use Drupal\DrupalExtension\Context\DrupalContext;
+
+class IsolatedDrupalContext extends DrupalContext {
+  /**
+   * @BeforeScenario
+   */
+  public function isolate() {
+    drupal_static_reset();
+    drupal_path_alias_whitelist_rebuild();
+  }
+
+  public function cleanNodes() {
+    $this->nodes = [];
+  }
+
+  public function cleanUsers() {
+    $this->users = [];
+  }
+
+  public function cleanTerms() {
+    $this->terms = [];
+  }
+
+  public function cleanRoles() {
+    $this->roles = [];
+  }
+}

--- a/tests/behat/features/bootstrap/IsolatedPropeopleContext.php
+++ b/tests/behat/features/bootstrap/IsolatedPropeopleContext.php
@@ -1,0 +1,21 @@
+<?php
+
+use Behat\Drupal\Propeople\PropeopleContext;
+
+class IsolatedPropeopleContext extends PropeopleContext {
+  public function cleanNodes() {
+    $this->nodes = [];
+  }
+
+  public function cleanUsers() {
+    $this->users = [];
+  }
+
+  public function cleanTerms() {
+    $this->terms = [];
+  }
+
+  public function cleanRoles() {
+    $this->roles = [];
+  }
+}

--- a/tests/behat/features/content_alerts_signup.feature
+++ b/tests/behat/features/content_alerts_signup.feature
@@ -3,18 +3,15 @@ Feature: Content alerts signup
   I want to sign up for content alerts
   So I can be alerted of the latest content
 
-  Background:
-    Given I set variable "pathauto_taxonomy_term_elife_categories_pattern" to string "new-category/[term:name]"
-
   @api @mink:goutte
   Scenario Outline: Verify that the content alert signup form is available on category pages
-    Given I set variable "elife_content_alerts_sign_up_ids" to array '{"new-category/<category-path>": "<id>"}'
-    And I set variable "elife_content_alerts_sign_up_gids" to array '{"new-category/<category-path>": "<gid>"}'
+    Given I set variable "elife_content_alerts_sign_up_ids" to array '{"category/<category-path>": "<id>"}'
+    And I set variable "elife_content_alerts_sign_up_gids" to array '{"category/<category-path>": "<gid>"}'
     And "elife_categories" terms:
       | name | field_elife_category_type |
       | <category> | <type> |
     And redirects are not followed
-    When I am on "new-category/<category-path>"
+    When I am on "category/<category-path>"
     And I should see a sign up form with id "<id>" and gid "<gid>"
     And I press the "<button_text>" button
     Then I should be on "http://crm.elifesciences.org/crm/civicrm/profile/create?reset=1&gid=<gid>"

--- a/tests/build/travis.behat.yml
+++ b/tests/build/travis.behat.yml
@@ -1,0 +1,7 @@
+imports:
+  - behat.yml.dist
+
+default:
+  extensions:
+    eLife\IsolatedDrupalBehatExtension:
+      db_url: 'mysql://root:@localhost/elife_profile'

--- a/tests/build/travis.local.settings.php
+++ b/tests/build/travis.local.settings.php
@@ -1,20 +1,4 @@
 <?php
 
-$databases = [
-  'default' =>
-    [
-      'default' =>
-        [
-          'database' => 'elife_profile',
-          'username' => 'root',
-          'password' => '',
-          'host' => 'localhost',
-          'port' => '',
-          'driver' => 'mysql',
-          'prefix' => '',
-        ],
-    ],
-];
-
 $conf['elife_article_markup_service_factory'] = '_elife_article_mock_markup_service';
 $conf['elife_node_binary'] = '%NODE_BIN%';


### PR DESCRIPTION
The Drupal extension doesn't run tests in isolation, so they can be affect by data that's already existing/changed by previous scenarios. This adds in the [Isolated-Drupal Behat Extension](https://github.com/elifesciences/isolated-drupal-behat-extension) to solve this.

Travis CI no longer installs the site, as there's no need to.
