### PR TITLE
Speed up article fixtures

### DIFF
--- a/tests/behat/features/archive.feature
+++ b/tests/behat/features/archive.feature
@@ -9,8 +9,7 @@ Feature: Archive
     And I should see "Article archive" in the "h1" element
 
   Scenario: No yearly overview
-    Given I set header "Content-Type" with value "application/json"
-    And I send a POST request to "api/article.json" with body:
+    Given there is an article:
       """
         {
           "title": "Article 01/10/2012",
@@ -32,15 +31,13 @@ Feature: Archive
           }
         }
       """
-    And the response code should be 200
     When I am on "/archive/2012"
     Then the response status code should be 404
     When I am on "/archive/2013"
     Then the response status code should be 404
 
   Scenario Outline: Appropriate heading set for archive listing
-    Given I set header "Content-Type" with value "application/json"
-    And I send a POST request to "api/article.json" with body:
+    Given there is an article:
       """
         {
           "title": "Article <pubdate>",
@@ -62,7 +59,6 @@ Feature: Archive
           }
         }
       """
-    And the response code should be 200
     When I am on "/archive/<url>"
     Then I should see "Article archive, <date>" in the "h1" element
 
@@ -72,8 +68,7 @@ Feature: Archive
       | 2013-05-01 | 2013/05 | May 2013 |
 
   Scenario Outline: Use the archive jump to dropdown
-    Given I set header "Content-Type" with value "application/json"
-    And I send a POST request to "api/article.json" with body:
+    Given there is an article:
       """
         {
           "title": "Article <pubdate>",
@@ -95,7 +90,6 @@ Feature: Archive
           }
         }
       """
-    And the response code should be 200
     And I am on "/archive"
     When I select "<option>" from "jump"
     And I press "Go"
@@ -108,8 +102,7 @@ Feature: Archive
 
   @javascript
   Scenario Outline: Use the archive jump to dropdown (javascript)
-    Given I set header "Content-Type" with value "application/json"
-    And I send a POST request to "api/article.json" with body:
+    Given there is an article:
       """
         {
           "title": "Article <pubdate>",
@@ -131,7 +124,6 @@ Feature: Archive
           }
         }
       """
-    And the response code should be 200
     And I am on "/archive"
     When I select "<option>" from "jump"
     Then the url should match "/archive/<dest_url>"
@@ -142,260 +134,220 @@ Feature: Archive
       | 2012-11-01 | November 2012 | 2012/11 |
 
   Scenario Outline: Correct number of articles for month
-    Given I set header "Content-Type" with value "application/json"
-    And I send a POST request to "api/article.json" with body:
+    Given there are articles:
       """
-        {
-          "title": "Article 2013-02-01",
-          "version": "1",
-          "doi": "10.7554/eLife.00001",
-          "volume": "1",
-          "elocation-id": "e00001",
-          "article-id": "00001",
-          "article-version-id": "00001.1",
-          "pub-date": "2013-02-01",
-          "path": "content/1/00001",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1",
-          "categories": {
-            "display-channel": [
-              "Research article"
-            ]
+        [
+          {
+            "title": "Article 2013-02-01",
+            "version": "1",
+            "doi": "10.7554/eLife.00001",
+            "volume": "1",
+            "elocation-id": "e00001",
+            "article-id": "00001",
+            "article-version-id": "00001.1",
+            "pub-date": "2013-02-01",
+            "path": "content/1/00001",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1",
+            "categories": {
+              "display-channel": [
+                "Research article"
+              ]
+            }
+          },
+          {
+            "title": "Article 2013-02-02",
+            "version": "1",
+            "doi": "10.7554/eLife.00002",
+            "volume": "1",
+            "elocation-id": "e00002",
+            "article-id": "00002",
+            "article-version-id": "00002.1",
+            "pub-date": "2013-02-02",
+            "path": "content/1/00002",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1",
+            "categories": {
+              "display-channel": [
+                "Research article"
+              ]
+            }
+          },
+          {
+            "title": "Article 2013-02-03",
+            "version": "1",
+            "doi": "10.7554/eLife.00003",
+            "volume": "1",
+            "elocation-id": "e00003",
+            "article-id": "00003",
+            "article-version-id": "00003.1",
+            "pub-date": "2013-02-03",
+            "path": "content/1/00003",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1",
+            "categories": {
+              "display-channel": [
+                "Research article"
+              ]
+            }
+          },
+          {
+            "title": "Article 2013-02-04",
+            "version": "1",
+            "doi": "10.7554/eLife.00004",
+            "volume": "1",
+            "elocation-id": "e00004",
+            "article-id": "00004",
+            "article-version-id": "00004.1",
+            "pub-date": "2013-02-04",
+            "path": "content/1/00004",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1",
+            "categories": {
+              "display-channel": [
+                "Research article"
+              ]
+            }
+          },
+          {
+            "title": "Article 2013-02-05",
+            "version": "1",
+            "doi": "10.7554/eLife.00005",
+            "volume": "1",
+            "elocation-id": "e00005",
+            "article-id": "00005",
+            "article-version-id": "00005.1",
+            "pub-date": "2013-02-05",
+            "path": "content/1/00005",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1",
+            "categories": {
+              "display-channel": [
+                "Research article"
+              ]
+            }
+          },
+          {
+            "title": "Article 2013-01-01",
+            "version": "1",
+            "doi": "10.7554/eLife.00011",
+            "volume": "1",
+            "elocation-id": "e00011",
+            "article-id": "00011",
+            "article-version-id": "00011.1",
+            "pub-date": "2013-01-01",
+            "path": "content/1/00011",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1",
+            "categories": {
+              "display-channel": [
+                "Research article"
+              ]
+            }
+          },
+          {
+            "title": "Article 2013-01-02",
+            "version": "1",
+            "doi": "10.7554/eLife.00012",
+            "volume": "1",
+            "elocation-id": "e00012",
+            "article-id": "00012",
+            "article-version-id": "00012.1",
+            "pub-date": "2013-01-02",
+            "path": "content/1/00012",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1",
+            "categories": {
+              "display-channel": [
+                "Research article"
+              ]
+            }
+          },
+          {
+            "title": "Article 2013-01-03",
+            "version": "1",
+            "doi": "10.7554/eLife.00013",
+            "volume": "1",
+            "elocation-id": "e00013",
+            "article-id": "00013",
+            "article-version-id": "00013.1",
+            "pub-date": "2013-01-03",
+            "path": "content/1/00013",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1",
+            "categories": {
+              "display-channel": [
+                "Research article"
+              ]
+            }
+          },
+          {
+            "title": "Article 2013-01-04",
+            "version": "1",
+            "doi": "10.7554/eLife.00014",
+            "volume": "1",
+            "elocation-id": "e00014",
+            "article-id": "00014",
+            "article-version-id": "00014.1",
+            "pub-date": "2013-01-04",
+            "path": "content/1/00014",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1",
+            "categories": {
+              "display-channel": [
+                "Research article"
+              ]
+            }
+          },
+          {
+            "title": "Article 2013-01-05",
+            "version": "1",
+            "doi": "10.7554/eLife.00015",
+            "volume": "1",
+            "elocation-id": "e00015",
+            "article-id": "00015",
+            "article-version-id": "00015.1",
+            "pub-date": "2013-01-05",
+            "path": "content/1/00015",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1",
+            "categories": {
+              "display-channel": [
+                "Research article"
+              ]
+            }
+          },
+          {
+            "title": "Article 2013-01-06",
+            "version": "1",
+            "doi": "10.7554/eLife.00016",
+            "volume": "1",
+            "elocation-id": "e00016",
+            "article-id": "00016",
+            "article-version-id": "00016.1",
+            "pub-date": "2013-01-06",
+            "path": "content/1/00016",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1",
+            "categories": {
+              "display-channel": [
+                "Research article"
+              ]
+            }
           }
-        }
+        ]
       """
-    And the response code should be 200
-    And I send a POST request to "api/article.json" with body:
-      """
-        {
-          "title": "Article 2013-02-02",
-          "version": "1",
-          "doi": "10.7554/eLife.00002",
-          "volume": "1",
-          "elocation-id": "e00002",
-          "article-id": "00002",
-          "article-version-id": "00002.1",
-          "pub-date": "2013-02-02",
-          "path": "content/1/00002",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1",
-          "categories": {
-            "display-channel": [
-              "Research article"
-            ]
-          }
-        }
-      """
-    And the response code should be 200
-    And I send a POST request to "api/article.json" with body:
-      """
-        {
-          "title": "Article 2013-02-03",
-          "version": "1",
-          "doi": "10.7554/eLife.00003",
-          "volume": "1",
-          "elocation-id": "e00003",
-          "article-id": "00003",
-          "article-version-id": "00003.1",
-          "pub-date": "2013-02-03",
-          "path": "content/1/00003",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1",
-          "categories": {
-            "display-channel": [
-              "Research article"
-            ]
-          }
-        }
-      """
-    And the response code should be 200
-    And I send a POST request to "api/article.json" with body:
-      """
-        {
-          "title": "Article 2013-02-04",
-          "version": "1",
-          "doi": "10.7554/eLife.00004",
-          "volume": "1",
-          "elocation-id": "e00004",
-          "article-id": "00004",
-          "article-version-id": "00004.1",
-          "pub-date": "2013-02-04",
-          "path": "content/1/00004",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1",
-          "categories": {
-            "display-channel": [
-              "Research article"
-            ]
-          }
-        }
-      """
-    And the response code should be 200
-    And I send a POST request to "api/article.json" with body:
-      """
-        {
-          "title": "Article 2013-02-05",
-          "version": "1",
-          "doi": "10.7554/eLife.00005",
-          "volume": "1",
-          "elocation-id": "e00005",
-          "article-id": "00005",
-          "article-version-id": "00005.1",
-          "pub-date": "2013-02-05",
-          "path": "content/1/00005",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1",
-          "categories": {
-            "display-channel": [
-              "Research article"
-            ]
-          }
-        }
-      """
-    And the response code should be 200
-    And I send a POST request to "api/article.json" with body:
-      """
-        {
-          "title": "Article 2013-01-01",
-          "version": "1",
-          "doi": "10.7554/eLife.00011",
-          "volume": "1",
-          "elocation-id": "e00011",
-          "article-id": "00011",
-          "article-version-id": "00011.1",
-          "pub-date": "2013-01-01",
-          "path": "content/1/00011",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1",
-          "categories": {
-            "display-channel": [
-              "Research article"
-            ]
-          }
-        }
-      """
-    And the response code should be 200
-    And I send a POST request to "api/article.json" with body:
-      """
-        {
-          "title": "Article 2013-01-02",
-          "version": "1",
-          "doi": "10.7554/eLife.00012",
-          "volume": "1",
-          "elocation-id": "e00012",
-          "article-id": "00012",
-          "article-version-id": "00012.1",
-          "pub-date": "2013-01-02",
-          "path": "content/1/00012",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1",
-          "categories": {
-            "display-channel": [
-              "Research article"
-            ]
-          }
-        }
-      """
-    And the response code should be 200
-    And I send a POST request to "api/article.json" with body:
-      """
-        {
-          "title": "Article 2013-01-03",
-          "version": "1",
-          "doi": "10.7554/eLife.00013",
-          "volume": "1",
-          "elocation-id": "e00013",
-          "article-id": "00013",
-          "article-version-id": "00013.1",
-          "pub-date": "2013-01-03",
-          "path": "content/1/00013",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1",
-          "categories": {
-            "display-channel": [
-              "Research article"
-            ]
-          }
-        }
-      """
-    And the response code should be 200
-    And I send a POST request to "api/article.json" with body:
-      """
-        {
-          "title": "Article 2013-01-04",
-          "version": "1",
-          "doi": "10.7554/eLife.00014",
-          "volume": "1",
-          "elocation-id": "e00014",
-          "article-id": "00014",
-          "article-version-id": "00014.1",
-          "pub-date": "2013-01-04",
-          "path": "content/1/00014",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1",
-          "categories": {
-            "display-channel": [
-              "Research article"
-            ]
-          }
-        }
-      """
-    And the response code should be 200
-    And I send a POST request to "api/article.json" with body:
-      """
-        {
-          "title": "Article 2013-01-05",
-          "version": "1",
-          "doi": "10.7554/eLife.00015",
-          "volume": "1",
-          "elocation-id": "e00015",
-          "article-id": "00015",
-          "article-version-id": "00015.1",
-          "pub-date": "2013-01-05",
-          "path": "content/1/00015",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1",
-          "categories": {
-            "display-channel": [
-              "Research article"
-            ]
-          }
-        }
-      """
-    And the response code should be 200
-    And I send a POST request to "api/article.json" with body:
-      """
-        {
-          "title": "Article 2013-01-06",
-          "version": "1",
-          "doi": "10.7554/eLife.00016",
-          "volume": "1",
-          "elocation-id": "e00016",
-          "article-id": "00016",
-          "article-version-id": "00016.1",
-          "pub-date": "2013-01-06",
-          "path": "content/1/00016",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1",
-          "categories": {
-            "display-channel": [
-              "Research article"
-            ]
-          }
-        }
-      """
-    And the response code should be 200
     When I am on "/archive/<url>"
     Then I should see <num> "article" elements
 
@@ -405,8 +357,7 @@ Feature: Archive
       | 2013/01 | 6 |
 
   Scenario Outline: Redirect if month does not have leading zero in url
-    Given I set header "Content-Type" with value "application/json"
-    And I send a POST request to "api/article.json" with body:
+    Given there is an article:
       """
         {
           "title": "Article <pubdate>",
@@ -428,7 +379,6 @@ Feature: Archive
           }
         }
       """
-    And the response code should be 200
     When I am on "/archive/<url>"
     Then the url should match "/archive/<new_url>"
 
@@ -440,191 +390,163 @@ Feature: Archive
 
   Scenario: Correct set of article types in the archive listing
     Given I set variable "elife_category_assets_weight" to array '["Editorial", "Feature article", "Insight", "Research article", "Short report", "Tools and resources", "Research advance", "Registered report"]'
-    And I set header "Content-Type" with value "application/json"
-    And I send a POST request to "api/article.json" with body:
+    And there are articles:
       """
-        {
-          "title": "Article 2015-03-01",
-          "version": "1",
-          "doi": "10.7554/eLife.00001",
-          "volume": "1",
-          "elocation-id": "e00001",
-          "article-id": "00001",
-          "article-version-id": "00001.1",
-          "pub-date": "2015-03-01",
-          "path": "content/1/00001",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1",
-          "categories": {
-            "display-channel": [
-              "Tools and resources"
-            ]
+        [
+          {
+            "title": "Article 2015-03-01",
+            "version": "1",
+            "doi": "10.7554/eLife.00001",
+            "volume": "1",
+            "elocation-id": "e00001",
+            "article-id": "00001",
+            "article-version-id": "00001.1",
+            "pub-date": "2015-03-01",
+            "path": "content/1/00001",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1",
+            "categories": {
+              "display-channel": [
+                "Tools and resources"
+              ]
+            }
+          },
+          {
+            "title": "Article 2015-03-02",
+            "version": "1",
+            "doi": "10.7554/eLife.00002",
+            "volume": "1",
+            "elocation-id": "e00002",
+            "article-id": "00002",
+            "article-version-id": "00002.1",
+            "pub-date": "2015-03-02",
+            "path": "content/1/00002",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1",
+            "categories": {
+              "display-channel": [
+                "Registered report"
+              ]
+            }
+          },
+          {
+            "title": "Article 2015-03-03",
+            "version": "1",
+            "doi": "10.7554/eLife.00003",
+            "volume": "1",
+            "elocation-id": "e00003",
+            "article-id": "00003",
+            "article-version-id": "00003.1",
+            "pub-date": "2015-03-03",
+            "path": "content/1/00003",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1",
+            "categories": {
+              "display-channel": [
+                "Research advance"
+              ]
+            }
+          },
+          {
+            "title": "Article 2015-03-04",
+            "version": "1",
+            "doi": "10.7554/eLife.00004",
+            "volume": "1",
+            "elocation-id": "e00004",
+            "article-id": "00004",
+            "article-version-id": "00004.1",
+            "pub-date": "2015-03-04",
+            "path": "content/1/00004",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1",
+            "categories": {
+              "display-channel": [
+                "Insight"
+              ]
+            }
+          },
+          {
+            "title": "Article 2015-03-05",
+            "version": "1",
+            "doi": "10.7554/eLife.00005",
+            "volume": "1",
+            "elocation-id": "e00005",
+            "article-id": "00005",
+            "article-version-id": "00005.1",
+            "pub-date": "2015-03-05",
+            "path": "content/1/00005",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1",
+            "categories": {
+              "display-channel": [
+                "Research article"
+              ]
+            }
+          },
+          {
+            "title": "Article 2015-03-06",
+            "version": "1",
+            "doi": "10.7554/eLife.00006",
+            "volume": "1",
+            "elocation-id": "e00006",
+            "article-id": "00006",
+            "article-version-id": "00006.1",
+            "pub-date": "2015-03-06",
+            "path": "content/1/00006",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1",
+            "categories": {
+              "display-channel": [
+                "Feature article"
+              ]
+            }
+          },
+          {
+            "title": "Article 2015-03-07",
+            "version": "1",
+            "doi": "10.7554/eLife.00007",
+            "volume": "1",
+            "elocation-id": "e00007",
+            "article-id": "00007",
+            "article-version-id": "00007.1",
+            "pub-date": "2015-03-07",
+            "path": "content/1/00007",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1",
+            "categories": {
+              "display-channel": [
+                "Short report"
+              ]
+            }
+          },
+          {
+            "title": "Article 2015-03-08",
+            "version": "1",
+            "doi": "10.7554/eLife.00008",
+            "volume": "1",
+            "elocation-id": "e00008",
+            "article-id": "00008",
+            "article-version-id": "00008.1",
+            "pub-date": "2015-03-08",
+            "path": "content/1/00008",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1",
+            "categories": {
+              "display-channel": [
+                "Editorial"
+              ]
+            }
           }
-        }
+        ]
       """
-    And the response code should be 200
-    And I send a POST request to "api/article.json" with body:
-      """
-        {
-          "title": "Article 2015-03-02",
-          "version": "1",
-          "doi": "10.7554/eLife.00002",
-          "volume": "1",
-          "elocation-id": "e00002",
-          "article-id": "00002",
-          "article-version-id": "00002.1",
-          "pub-date": "2015-03-02",
-          "path": "content/1/00002",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1",
-          "categories": {
-            "display-channel": [
-              "Registered report"
-            ]
-          }
-        }
-      """
-    And the response code should be 200
-    And I send a POST request to "api/article.json" with body:
-      """
-        {
-          "title": "Article 2015-03-03",
-          "version": "1",
-          "doi": "10.7554/eLife.00003",
-          "volume": "1",
-          "elocation-id": "e00003",
-          "article-id": "00003",
-          "article-version-id": "00003.1",
-          "pub-date": "2015-03-03",
-          "path": "content/1/00003",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1",
-          "categories": {
-            "display-channel": [
-              "Research advance"
-            ]
-          }
-        }
-      """
-    And the response code should be 200
-    And I send a POST request to "api/article.json" with body:
-      """
-        {
-          "title": "Article 2015-03-04",
-          "version": "1",
-          "doi": "10.7554/eLife.00004",
-          "volume": "1",
-          "elocation-id": "e00004",
-          "article-id": "00004",
-          "article-version-id": "00004.1",
-          "pub-date": "2015-03-04",
-          "path": "content/1/00004",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1",
-          "categories": {
-            "display-channel": [
-              "Insight"
-            ]
-          }
-        }
-      """
-    And the response code should be 200
-    And I send a POST request to "api/article.json" with body:
-      """
-        {
-          "title": "Article 2015-03-05",
-          "version": "1",
-          "doi": "10.7554/eLife.00005",
-          "volume": "1",
-          "elocation-id": "e00005",
-          "article-id": "00005",
-          "article-version-id": "00005.1",
-          "pub-date": "2015-03-05",
-          "path": "content/1/00005",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1",
-          "categories": {
-            "display-channel": [
-              "Research article"
-            ]
-          }
-        }
-      """
-    And the response code should be 200
-    And I send a POST request to "api/article.json" with body:
-      """
-        {
-          "title": "Article 2015-03-06",
-          "version": "1",
-          "doi": "10.7554/eLife.00006",
-          "volume": "1",
-          "elocation-id": "e00006",
-          "article-id": "00006",
-          "article-version-id": "00006.1",
-          "pub-date": "2015-03-06",
-          "path": "content/1/00006",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1",
-          "categories": {
-            "display-channel": [
-              "Feature article"
-            ]
-          }
-        }
-      """
-    And the response code should be 200
-    And I send a POST request to "api/article.json" with body:
-      """
-        {
-          "title": "Article 2015-03-07",
-          "version": "1",
-          "doi": "10.7554/eLife.00007",
-          "volume": "1",
-          "elocation-id": "e00007",
-          "article-id": "00007",
-          "article-version-id": "00007.1",
-          "pub-date": "2015-03-07",
-          "path": "content/1/00007",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1",
-          "categories": {
-            "display-channel": [
-              "Short report"
-            ]
-          }
-        }
-      """
-    And the response code should be 200
-    And I send a POST request to "api/article.json" with body:
-      """
-        {
-          "title": "Article 2015-03-08",
-          "version": "1",
-          "doi": "10.7554/eLife.00008",
-          "volume": "1",
-          "elocation-id": "e00008",
-          "article-id": "00008",
-          "article-version-id": "00008.1",
-          "pub-date": "2015-03-08",
-          "path": "content/1/00008",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1",
-          "categories": {
-            "display-channel": [
-              "Editorial"
-            ]
-          }
-        }
-      """
-    And the response code should be 200
     When I am on "/archive/2015/03"
     Then I should see "Editorial" in the ".view-elife-archive-by-month h3:nth-of-type(1)" element
     Then I should see "Feature article" in the ".view-elife-archive-by-month h3:nth-of-type(2)" element

--- a/tests/behat/features/article_tooltip.feature
+++ b/tests/behat/features/article_tooltip.feature
@@ -5,8 +5,7 @@ Feature: Footnote
 
   @hover
   Scenario Outline: Information in author tooltip
-    Given I set header "Content-Type" with value "application/json"
-    And I send a POST request to "api/article.json" with body:
+    Given there is an article:
       """
         {
           "title": "VOR 00013",
@@ -155,7 +154,6 @@ Feature: Footnote
           }
         }
       """
-    And the response code should be 200
     And I go to "content/3/e00013"
     # Then I should see "author-tooltip-name" in the ".elife-article-author-item" element
     Then I should see "<author>" in the ".author-list-full li:nth-of-type(<n>) .author-tooltip .author-tooltip-name" element

--- a/tests/behat/features/article_tooltip_close.feature
+++ b/tests/behat/features/article_tooltip_close.feature
@@ -6,8 +6,7 @@ Feature: Footnote
 
   @javascript
   Scenario: Closing author tooltip by close button
-    Given I set header "Content-Type" with value "application/json"
-    And I send a POST request to "api/article.json" with body:
+    Given there is an article:
       """
         {
           "title": "VOR 05003",
@@ -24,6 +23,5 @@ Feature: Footnote
           "publish": "1"
         }
       """
-    And the response code should be 200
     And I go to "content/4/e05003"
     Then I should see "Close" in the "#cluetip .cluetip-outer .cluetip-inner .cluetip-close a" element

--- a/tests/behat/features/article_tooltip_contribution.feature
+++ b/tests/behat/features/article_tooltip_contribution.feature
@@ -5,8 +5,7 @@ Feature: Contribution
 
   @hover
   Scenario Outline: Contribution listed in author tooltip
-    Given I set header "Content-Type" with value "application/json"
-    And I send a POST request to "api/article.json" with body:
+    Given there is an article:
       """
         {
           "title": "VOR 03895",
@@ -123,7 +122,6 @@ Feature: Contribution
           }
         }
       """
-    And the response code should be 200
     And I go to "content/3/e03895"
     Then I should see "<author>" in the ".author-list-full li:nth-of-type(<n>) .author-tooltip .author-tooltip-name" element
     Then I should see "Contributed equally with:" in the ".author-list-full li:nth-of-type(<n>) .author-tooltip-equal-contrib .author-tooltip-label" element

--- a/tests/behat/features/article_tooltip_corresponding_author.feature
+++ b/tests/behat/features/article_tooltip_corresponding_author.feature
@@ -5,8 +5,7 @@ Feature: Footnote
 
   @hover
   Scenario Outline: Author has provided email id
-    Given I set header "Content-Type" with value "application/json"
-    And I send a POST request to "api/article.json" with body:
+    Given there is an article:
       """
         {
           "title": "VOR 07091",
@@ -134,7 +133,6 @@ Feature: Footnote
           }
         }
       """
-    And the response code should be 200
     And I go to "content/4/e07091"
     Then I should see "<author>" in the ".author-list-full li:nth-of-type(<n>) .author-tooltip .author-tooltip-name" element
     Then I should see the url "<author_email>" in the "href" attribute of the ".author-list-full li:nth-of-type(<n>) .author-tooltip .author-tooltip-corresp .author-tooltip-text a" element
@@ -147,8 +145,7 @@ Feature: Footnote
       | Pradipta Ghosh      | mailto:prghosh@ucsd.edu | 2 | prghosh@ucsd.edu |
 
   Scenario Outline: Author has not provided email id
-    Given I set header "Content-Type" with value "application/json"
-    And I send a POST request to "api/article.json" with body:
+    Given there is an article:
       """
         {
           "title": "VOR 07091",
@@ -189,7 +186,6 @@ Feature: Footnote
           }
         }
       """
-    And the response code should be 200
     And I go to "content/4/e07091"
     Then I should see "Miguel Abal" in the ".author-list-full li:nth-of-type(<n>) .author-tooltip .author-tooltip-name" element
     And I should not see "For Correspondence" in the ".author-list-full li:nth-of-type(<n>) .author-tooltip" element

--- a/tests/behat/features/article_tooltip_fn_affiliations.feature
+++ b/tests/behat/features/article_tooltip_fn_affiliations.feature
@@ -4,8 +4,7 @@ Feature: Footnote
   I should be able to see the list of institutions in the author tooltip
 
   Scenario Outline: List of institutions author is associated with is shown in the tooltip
-    Given I set header "Content-Type" with value "application/json"
-    And I send a POST request to "api/article.json" with body:
+    Given there is an article:
       """
         {
           "title": "VOR 04046",
@@ -46,7 +45,6 @@ Feature: Footnote
           }
         }
       """
-    And the response code should be 200
     And I go to "content/3/e04046"
     Then I should see "<author>" in the ".author-tooltip-name" element
     And I should see "<dept>" in the ".dept" element

--- a/tests/behat/features/article_tooltip_fn_alphabetical.feature
+++ b/tests/behat/features/article_tooltip_fn_alphabetical.feature
@@ -4,8 +4,7 @@ Feature: Alphabetical
   I should be listed in alphabetical order with other authors
 
   Scenario Outline: View alphabetical listing of authors when there is more than one contributor
-    Given I set header "Content-Type" with value "application/json"
-    And I send a POST request to "api/article.json" with body:
+    Given there is an article:
       """
         {
           "title": "VOR 00731",
@@ -140,7 +139,6 @@ Feature: Alphabetical
           }
         }
       """
-    And the response code should be 200
     And I go to "content/2/e00731"
     Then I should see "<author>" in the ".author-list-full li:nth-of-type(<n>) .author-tooltip .author-tooltip-name" element
     And I should see "Listed in alphabetical order with: Sophien Kamoun, Johannes Krause, Marco Thines, Detlef Weigel"
@@ -152,8 +150,7 @@ Feature: Alphabetical
       | Marco Thines    | 3 |
 
   Scenario: No alphabetical listing of authors when there are no equal co-contributors
-    Given I set header "Content-Type" with value "application/json"
-    And I send a POST request to "api/article.json" with body:
+    Given there is an article:
       """
         {
           "title": "VOR 00731",
@@ -203,7 +200,6 @@ Feature: Alphabetical
           }
         }
       """
-    And the response code should be 200
     And I go to "content/2/e00731"
     Then I should see "Frank N Martin" in the ".author-tooltip-name" element
     And I should not see "Listed in alphabetical order with:" in the ".author-tooltip-label" element

--- a/tests/behat/features/article_tooltip_fn_competing_interests.feature
+++ b/tests/behat/features/article_tooltip_fn_competing_interests.feature
@@ -5,8 +5,7 @@ Feature: Competing Interests in Footnotes
 
   @hover
   Scenario: Author has not declared competing interests
-    Given I set header "Content-Type" with value "application/json"
-    And I send a POST request to "api/article.json" with body:
+    Given there is an article:
       """
         {
           "title": "VOR 05003",
@@ -53,14 +52,12 @@ Feature: Competing Interests in Footnotes
           }
         }
       """
-    And the response code should be 200
     And I go to "content/4/e05003"
     Then I should see "No competing interests declared" in the ".author-tooltip-conflict" element
     # And I should see "No competing interests declared" in the ".author-info-title" element
 
   Scenario Outline: Author has declared competing interests
-    Given I set header "Content-Type" with value "application/json"
-    And I send a POST request to "api/article.json" with body:
+    Given there is an article:
       """
         {
           "title": "VOR 00007",
@@ -107,7 +104,6 @@ Feature: Competing Interests in Footnotes
           }
         }
       """
-    And the response code should be 200
     And I go to "content/1/e00007"
     Then I should see "<author>" in the ".author-list-full li:nth-of-type(<n>) .author-tooltip .author-tooltip-name" element
     And I should see "Competing Interests:" in the ".author-tooltip-label" element

--- a/tests/behat/features/article_tooltip_fn_deceased.feature
+++ b/tests/behat/features/article_tooltip_fn_deceased.feature
@@ -5,8 +5,7 @@ Feature: Deceased
 
   @hover
   Scenario: Author is deceased
-    Given I set header "Content-Type" with value "application/json"
-    And I send a POST request to "api/article.json" with body:
+    Given there is an article:
       """
         {
           "title": "VOR 01861",
@@ -57,14 +56,12 @@ Feature: Deceased
           }
         }
       """
-    And the response code should be 200
     And I go to "content/3/e01861"
     Then I should see "Jonathan Widom" in the ".elife-article-author-item" element
     And I should see "Deceased" in the ".author-tooltip" element
 
   Scenario: Author is not deceased
-    Given I set header "Content-Type" with value "application/json"
-    And I send a POST request to "api/article.json" with body:
+    Given there is an article:
       """
         {
           "title": "VOR 01861",
@@ -111,7 +108,6 @@ Feature: Deceased
           }
         }
       """
-    And the response code should be 200
     And I go to "content/3/e01861"
     Then I should see "Jonathan Widom" in the ".elife-article-author-item" element
     And I should not see "Deceased" in the ".author-tooltip" element

--- a/tests/behat/features/bootstrap/FeatureContext.php
+++ b/tests/behat/features/bootstrap/FeatureContext.php
@@ -1,5 +1,6 @@
 <?php
 
+use Behat\Gherkin\Node\PyStringNode;
 use Behat\Mink\Driver\GoutteDriver;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Drupal\DrupalExtension\Context\RawDrupalContext;
@@ -45,6 +46,42 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
   public function redirectsAreNotFollowed() {
     $this->canIntercept();
     $this->getSession()->getDriver()->getClient()->followRedirects(FALSE);
+  }
+
+  /**
+   * Set up an article.
+   *
+   * @param PyStringNode $string
+   *   JSON article.
+   *
+   * @Given /^there is an article:$/
+   */
+  public function thereIsAnArticle(PyStringNode $string) {
+    module_load_include('inc', 'elife_services', 'resources/article');
+
+    _elife_services_article_create($string->getRaw());
+  }
+
+  /**
+   * Sets up a number of articles.
+   *
+   * @param PyStringNode $string
+   *   JSON array of articles.
+   *
+   * @Given /^there are articles:$/
+   */
+  public function thereAreArticles(PyStringNode $string) {
+    module_load_include('inc', 'elife_services', 'resources/article');
+
+    $json = @json_decode($string, TRUE);
+
+    if (FALSE === is_array($json)) {
+      throw new LogicException('Invalid JSON');
+    }
+
+    foreach ($json as $article_json) {
+      _elife_services_article_create(json_encode($article_json));
+    }
   }
 
   // the versions should be ordered "05224,05224.early.v1,05224.early.v2"

--- a/tests/behat/features/collections.feature
+++ b/tests/behat/features/collections.feature
@@ -5,100 +5,88 @@ Feature: Collections
 
   @api
   Scenario: Create collection page for Algoriphagus
-    Given I set header "Content-Type" with value "application/json"
-    And I send a POST request to "api/article.json" with body:
+    Given there are articles:
       """
-        {
-          "title": "VOR 05224 v1",
-          "version": "1",
-          "doi": "10.7554/eLife.05224.1",
-          "volume": "4",
-          "elocation-id": "e05224",
-          "article-id": "05224",
-          "article-version-id": "05224.1",
-          "pub-date": "1979-08-17",
-          "path": "content/4/e05224v1",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1",
-          "keywords": {
-            "author-keywords": [
-              "Algoriphagus"
-            ]
+        [
+          {
+            "title": "VOR 05224 v1",
+            "version": "1",
+            "doi": "10.7554/eLife.05224.1",
+            "volume": "4",
+            "elocation-id": "e05224",
+            "article-id": "05224",
+            "article-version-id": "05224.1",
+            "pub-date": "1979-08-17",
+            "path": "content/4/e05224v1",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1",
+            "keywords": {
+              "author-keywords": [
+                "Algoriphagus"
+              ]
+            }
+          },
+          {
+            "title": "VOR 05224 v2",
+            "version": "2",
+            "doi": "10.7554/eLife.05224.2",
+            "volume": "4",
+            "elocation-id": "e05224",
+            "article-id": "05224",
+            "article-version-id": "05224.2",
+            "pub-date": "1979-08-17",
+            "path": "content/4/e05224v2",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1",
+            "keywords": {
+              "author-keywords": [
+                "Algoriphagus"
+              ]
+            }
+          },
+          {
+            "title": "VOR 05225 v1",
+            "version": "1",
+            "doi": "10.7554/eLife.05225.1",
+            "volume": "4",
+            "elocation-id": "e05225",
+            "article-id": "05225",
+            "article-version-id": "05225.1",
+            "pub-date": "1979-08-17",
+            "path": "content/4/e05225v1",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1",
+            "keywords": {
+              "author-keywords": [
+                "Algoriphagus",
+                "bacterial sulfonolipid"
+              ]
+            }
+          },
+          {
+            "title": "VOR 05226 v1",
+            "version": "1",
+            "doi": "10.7554/eLife.05226.1",
+            "volume": "4",
+            "elocation-id": "e05226",
+            "article-id": "05226",
+            "article-version-id": "05226.1",
+            "pub-date": "1979-08-17",
+            "path": "content/4/e05226v1",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1",
+            "keywords": {
+              "author-keywords": [
+                "bacterial sulfonolipid"
+              ]
+            }
           }
-        }
+        ]
       """
-    And the response code should be 200
-    And I send a POST request to "api/article.json" with body:
-      """
-        {
-          "title": "VOR 05224 v2",
-          "version": "2",
-          "doi": "10.7554/eLife.05224.2",
-          "volume": "4",
-          "elocation-id": "e05224",
-          "article-id": "05224",
-          "article-version-id": "05224.2",
-          "pub-date": "1979-08-17",
-          "path": "content/4/e05224v2",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1",
-          "keywords": {
-            "author-keywords": [
-              "Algoriphagus"
-            ]
-          }
-        }
-      """
-    And the response code should be 200
-    And I send a POST request to "api/article.json" with body:
-      """
-        {
-          "title": "VOR 05225 v1",
-          "version": "1",
-          "doi": "10.7554/eLife.05225.1",
-          "volume": "4",
-          "elocation-id": "e05225",
-          "article-id": "05225",
-          "article-version-id": "05225.1",
-          "pub-date": "1979-08-17",
-          "path": "content/4/e05225v1",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1",
-          "keywords": {
-            "author-keywords": [
-              "Algoriphagus",
-              "bacterial sulfonolipid"
-            ]
-          }
-        }
-      """
-    And the response code should be 200
-    And I send a POST request to "api/article.json" with body:
-      """
-        {
-          "title": "VOR 05226 v1",
-          "version": "1",
-          "doi": "10.7554/eLife.05226.1",
-          "volume": "4",
-          "elocation-id": "e05226",
-          "article-id": "05226",
-          "article-version-id": "05226.1",
-          "pub-date": "1979-08-17",
-          "path": "content/4/e05226v1",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1",
-          "keywords": {
-            "author-keywords": [
-              "bacterial sulfonolipid"
-            ]
-          }
-        }
-      """
-    And the response code should be 200
     When I am viewing an "elife_collection" content:
       | field_elife_c_keyword | Algoriphagus |
     Then I should see text matching "VOR 05224 v2"

--- a/tests/behat/features/front_matter.feature
+++ b/tests/behat/features/front_matter.feature
@@ -5,8 +5,7 @@ Feature: Front Matter
 
   @api
   Scenario: Load cover item to homepage referencing an article
-    Given I set header "Content-Type" with value "application/json"
-    And I send a POST request to "api/article.json" with body:
+    Given there is an article:
       """
         {
           "title": "VOR 05224 v1",
@@ -23,7 +22,6 @@ Feature: Front Matter
           "publish": "1"
         }
       """
-    And the response code should be 200
     And "elife_cover" content:
       | title | field_elife_fm_reference | field_elife_fm_reference_type |
       | Check out 05224 | 05224 | Article |
@@ -47,79 +45,67 @@ Feature: Front Matter
 
   @api
   Scenario: Load front matter items to homepage
-    Given I set header "Content-Type" with value "application/json"
-    And I send a POST request to "api/article.json" with body:
+    Given there are articles:
       """
-        {
-          "title": "VOR 05224",
-          "version": "1",
-          "doi": "10.7554/eLife.05224.1",
-          "volume": "4",
-          "elocation-id": "e05224",
-          "article-id": "05224",
-          "article-version-id": "05224.1",
-          "pub-date": "1979-08-17",
-          "path": "content/4/e05224",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1"
-        }
+        [
+          {
+            "title": "VOR 05224",
+            "version": "1",
+            "doi": "10.7554/eLife.05224.1",
+            "volume": "4",
+            "elocation-id": "e05224",
+            "article-id": "05224",
+            "article-version-id": "05224.1",
+            "pub-date": "1979-08-17",
+            "path": "content/4/e05224",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1"
+          },
+          {
+            "title": "VOR 05225",
+            "version": "1",
+            "doi": "10.7554/eLife.05225.1",
+            "volume": "4",
+            "elocation-id": "e05225",
+            "article-id": "05225",
+            "article-version-id": "05225.1",
+            "pub-date": "1979-08-17",
+            "path": "content/4/e05225",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1"
+          },
+          {
+            "title": "VOR 05226",
+            "version": "1",
+            "doi": "10.7554/eLife.05226.1",
+            "volume": "4",
+            "elocation-id": "e05226",
+            "article-id": "05226",
+            "article-version-id": "05226.1",
+            "pub-date": "1979-08-17",
+            "path": "content/4/e05226",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1"
+          },
+          {
+            "title": "VOR 05227",
+            "version": "1",
+            "doi": "10.7554/eLife.05227.1",
+            "volume": "4",
+            "elocation-id": "e05227",
+            "article-id": "05227",
+            "article-version-id": "05227.1",
+            "pub-date": "1979-08-17",
+            "path": "content/4/e05227",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1"
+          }
+        ]
       """
-    And the response code should be 200
-    And I send a POST request to "api/article.json" with body:
-      """
-        {
-          "title": "VOR 05225",
-          "version": "1",
-          "doi": "10.7554/eLife.05225.1",
-          "volume": "4",
-          "elocation-id": "e05225",
-          "article-id": "05225",
-          "article-version-id": "05225.1",
-          "pub-date": "1979-08-17",
-          "path": "content/4/e05225",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1"
-        }
-      """
-    And the response code should be 200
-    And I send a POST request to "api/article.json" with body:
-      """
-        {
-          "title": "VOR 05226",
-          "version": "1",
-          "doi": "10.7554/eLife.05226.1",
-          "volume": "4",
-          "elocation-id": "e05226",
-          "article-id": "05226",
-          "article-version-id": "05226.1",
-          "pub-date": "1979-08-17",
-          "path": "content/4/e05226",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1"
-        }
-      """
-    And the response code should be 200
-    And I send a POST request to "api/article.json" with body:
-      """
-        {
-          "title": "VOR 05227",
-          "version": "1",
-          "doi": "10.7554/eLife.05227.1",
-          "volume": "4",
-          "elocation-id": "e05227",
-          "article-id": "05227",
-          "article-version-id": "05227.1",
-          "pub-date": "1979-08-17",
-          "path": "content/4/e05227",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1"
-        }
-      """
-    And the response code should be 200
     And "elife_front_matter" content:
       | title | field_elife_fm_reference | field_elife_fm_reference_type |
       | Check out 05224 | 05224 | Article |

--- a/tests/behat/features/podcast.feature
+++ b/tests/behat/features/podcast.feature
@@ -8,8 +8,7 @@ Feature: Podcast
     Given "elife_podcast" content:
       | title      | field_elife_p_articles |
       | Podcast 13 | 05224                  |
-    And I set header "Content-Type" with value "application/json"
-    And I send a POST request to "api/article.json" with body:
+    And there is an article:
       """
         {
           "title": "VOR 05224",
@@ -26,7 +25,6 @@ Feature: Podcast
           "publish": "1"
         }
       """
-    And the response code should be 200
     When I am on "content/4/e05224"
     Then I should see the link "Podcast 13" in the "sidebar" region
 
@@ -35,63 +33,53 @@ Feature: Podcast
     Given "elife_podcast" content:
       | title      | field_elife_p_articles |
       | Podcast 13 | 05224, 05226           |
-    And I set header "Content-Type" with value "application/json"
-    And I send a POST request to "api/article.json" with body:
+    And there are articles:
       """
-        {
-          "title": "VOR 05224",
-          "version": "1",
-          "doi": "10.7554/eLife.05224",
-          "volume": "4",
-          "elocation-id": "e05224",
-          "article-id": "05224",
-          "article-version-id": "05224.1",
-          "pub-date": "1979-08-17",
-          "path": "content/4/e05224",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1"
-        }
+        [
+          {
+            "title": "VOR 05224",
+            "version": "1",
+            "doi": "10.7554/eLife.05224",
+            "volume": "4",
+            "elocation-id": "e05224",
+            "article-id": "05224",
+            "article-version-id": "05224.1",
+            "pub-date": "1979-08-17",
+            "path": "content/4/e05224",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1"
+          },
+          {
+            "title": "VOR 05225",
+            "version": "1",
+            "doi": "10.7554/eLife.05225",
+            "volume": "4",
+            "elocation-id": "e05225",
+            "article-id": "05225",
+            "article-version-id": "05225.1",
+            "pub-date": "1979-08-18",
+            "path": "content/4/e05225",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1"
+          },
+            {
+            "title": "VOR 05226",
+            "version": "1",
+            "doi": "10.7554/eLife.05226",
+            "volume": "4",
+            "elocation-id": "e05226",
+            "article-id": "05226",
+            "article-version-id": "05226.1",
+            "pub-date": "1979-08-19",
+            "path": "content/4/e05226",
+            "article-type": "research-article",
+            "status": "VOR",
+            "publish": "1"
+          }
+        ]
       """
-    And the response code should be 200
-    And I set header "Content-Type" with value "application/json"
-    And I send a POST request to "api/article.json" with body:
-      """
-        {
-          "title": "VOR 05225",
-          "version": "1",
-          "doi": "10.7554/eLife.05225",
-          "volume": "4",
-          "elocation-id": "e05225",
-          "article-id": "05225",
-          "article-version-id": "05225.1",
-          "pub-date": "1979-08-18",
-          "path": "content/4/e05225",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1"
-        }
-      """
-    And the response code should be 200
-    And I set header "Content-Type" with value "application/json"
-    And I send a POST request to "api/article.json" with body:
-      """
-        {
-          "title": "VOR 05226",
-          "version": "1",
-          "doi": "10.7554/eLife.05226",
-          "volume": "4",
-          "elocation-id": "e05226",
-          "article-id": "05226",
-          "article-version-id": "05226.1",
-          "pub-date": "1979-08-19",
-          "path": "content/4/e05226",
-          "article-type": "research-article",
-          "status": "VOR",
-          "publish": "1"
-        }
-      """
-    And the response code should be 200
     Then I am on "content/4/e05224"
     And I should see the link "Podcast 13" in the "sidebar" region
     And I am on "content/4/e05225"


### PR DESCRIPTION
Currently article fixtures are set up through the API, which involves actually using HTTP. This is unnecessary (and probably a bit slow) when we're not actually testing the API, so this PR bypasses it.

As a side-effect, it also simplifies the steps.
