### PR TITLE
Run Behat in strict mode

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -50,8 +50,8 @@ done
 # Run behat tests
 result=0
 cd $behatdir
-echo "$behatdir: $bdpcdir --format '$FORMAT' --tags '$TAGS'"
-$bdpcdir --format "$FORMAT" --tags "$TAGS"
+echo "$behatdir: $bdpcdir --format '$FORMAT' --tags '$TAGS' --strict"
+$bdpcdir --format "$FORMAT" --tags "$TAGS" --strict
 rc=$?
 if [ $rc != 0 ] ; then
     result=$rc


### PR DESCRIPTION
Behat must be run in strict mode, otherwise undefined steps aren't considered a failure.
