### PR TITLE
Set up Monolog

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -340,6 +340,82 @@
             "time": "2015-06-16 11:50:24"
         },
         {
+            "name": "monolog/monolog",
+            "version": "1.16.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "c0c0b4bee3aabce7182876b0d912ef2595563db7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/c0c0b4bee3aabce7182876b0d912ef2595563db7",
+                "reference": "c0c0b4bee3aabce7182876b0d912ef2595563db7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "psr/log": "~1.0"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^2.4.9",
+                "doctrine/couchdb": "~1.0@dev",
+                "graylog2/gelf-php": "~1.0",
+                "php-console/php-console": "^3.1.3",
+                "phpunit/phpunit": "~4.5",
+                "phpunit/phpunit-mock-objects": "2.3.0",
+                "raven/raven": "~0.8",
+                "ruflin/elastica": ">=0.90 <3.0",
+                "swiftmailer/swiftmailer": "~5.3",
+                "videlalvaro/php-amqplib": "~2.4"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-mongo": "Allow sending log messages to a MongoDB server",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "php-console/php-console": "Allow sending log messages to Google Chrome",
+                "raven/raven": "Allow sending log messages to a Sentry server",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.16.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "http://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "time": "2015-08-09 17:44:44"
+        },
+        {
             "name": "phpcollection/phpcollection",
             "version": "0.4.0",
             "source": {
@@ -437,6 +513,44 @@
                 "type"
             ],
             "time": "2014-01-09 22:37:17"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Psr\\Log\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2012-12-21 11:40:51"
         },
         {
             "name": "symfony/process",
@@ -3077,6 +3191,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "monolog/monolog": 0,
         "php": 0,
         "jms/serializer": 0,
         "symfony/process": 0,

--- a/src/elife_profile/elife_profile.info
+++ b/src/elife_profile/elife_profile.info
@@ -23,7 +23,6 @@ dependencies[] = taxonomy
 ; Development modules.
 dependencies[] = admin_devel
 dependencies[] = context_ui
-dependencies[] = dblog
 dependencies[] = delta_ui
 dependencies[] = devel
 dependencies[] = ds_ui
@@ -129,6 +128,7 @@ dependencies[] = elife_early_careers
 dependencies[] = elife_footer
 dependencies[] = elife_front_matter
 dependencies[] = elife_header
+dependencies[] = elife_monolog
 dependencies[] = elife_person_profile
 dependencies[] = elife_podcast
 dependencies[] = elife_resources

--- a/src/elife_profile/modules/custom/elife_monolog/composer.json
+++ b/src/elife_profile/modules/custom/elife_monolog/composer.json
@@ -1,0 +1,13 @@
+{
+    "require": {
+        "php": ">=5.4",
+        "monolog/monolog": "~1.16"
+    },
+    "autoload": {
+        "psr-4": {
+            "eLife\\Monolog\\": [
+                "src/"
+            ]
+        }
+    }
+}

--- a/src/elife_profile/modules/custom/elife_monolog/elife_monolog.info
+++ b/src/elife_profile/modules/custom/elife_monolog/elife_monolog.info
@@ -1,0 +1,6 @@
+name = eLife: Monolog
+core = 7.x
+package = eLife
+version = 7.x-1.0
+project = elife_monolog
+project path = profiles/elife_profile/modules/custom

--- a/src/elife_profile/modules/custom/elife_monolog/elife_monolog.module
+++ b/src/elife_profile/modules/custom/elife_monolog/elife_monolog.module
@@ -1,0 +1,80 @@
+<?php
+
+use Monolog\Logger;
+use Psr\Log\LogLevel;
+
+/**
+ * Implements hook_watchdog().
+ */
+function elife_monolog_watchdog(array $log_entry) {
+  $logger = _elife_monolog_logger($log_entry['type']);
+
+  $context = array_filter(array_intersect_key($log_entry, [
+    'uid' => 'uid',
+    'request_uri' => 'request_uri',
+    'referer' => 'referer',
+    'ip' => 'ip',
+    'link' => 'link',
+  ]));
+  $message = strip_tags(!isset($log_entry['variables']) ? $log_entry['message'] : strtr($log_entry['message'], $log_entry['variables']));
+  $level = elife_monolog_level($log_entry['severity']);
+
+  $logger->log($level, $message, $context);
+}
+
+/**
+ * Get a logger.
+ *
+ * @param string $type
+ *   Type.
+ *
+ * @return Logger
+ *   Logger.
+ */
+function _elife_monolog_logger($type) {
+  $logger = new Logger($type);
+
+  if ($handlers = variable_get('elife_monolog_handlers')) {
+    if (!is_array($handlers)) {
+      $handlers = [$handlers];
+    }
+    foreach ($handlers as $handler) {
+      $logger->pushHandler($handler);
+    }
+  }
+
+  if ($processors = variable_get('elife_monolog_processors')) {
+    if (!is_array($processors)) {
+      $processors = [$processors];
+    }
+    foreach ($processors as $processor) {
+      $logger->pushProcessor($processor);
+    }
+  }
+
+  return $logger;
+}
+
+/**
+ * Maps a Watchdog severity level to a PSR-3 severity level.
+ *
+ * @param string $level
+ *   The Watchdog severity level.
+ *
+ * @return int
+ *   The PSR-3 severity level.
+ */
+function elife_monolog_level($level) {
+  static $levels = [
+    WATCHDOG_DEBUG => LogLevel::DEBUG,
+    WATCHDOG_INFO => LogLevel::INFO,
+    WATCHDOG_NOTICE => LogLevel::NOTICE,
+    WATCHDOG_WARNING => LogLevel::WARNING,
+    WATCHDOG_ERROR => LogLevel::ERROR,
+    WATCHDOG_CRITICAL => LogLevel::CRITICAL,
+    WATCHDOG_ALERT => LogLevel::ALERT,
+    WATCHDOG_EMERGENCY => LogLevel::EMERGENCY,
+  ];
+
+  return isset($levels[$level]) ? $levels[$level] : LogLevel::NOTICE;
+}

--- a/src/elife_profile/modules/custom/elife_monolog/src/eLifeJsonFormatter.php
+++ b/src/elife_profile/modules/custom/elife_monolog/src/eLifeJsonFormatter.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace eLife\Monolog;
+
+use DateTime;
+use DateTimeInterface;
+use Monolog\Formatter\JsonFormatter;
+
+/**
+ * Formats Monolog log items in the eLife JSON standard.
+ */
+final class eLifeJsonFormatter extends JsonFormatter {
+  /**
+   * Process name.
+   *
+   * @var string
+   */
+  private $processName;
+
+  /**
+   * Constructor.
+   *
+   * @param string $process_name
+   *   Process name.
+   */
+  public function __construct($process_name) {
+    $this->processName = $process_name;
+
+    parent::__construct();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function format(array $record) {
+    $replacement = [];
+
+    $map = [
+      'timestamp' => 'datetime',
+      'log_level' => 'level_name',
+      'section' => 'channel',
+      'message' => 'message',
+      'context' => 'context',
+      'extra' => 'extra',
+    ];
+
+    foreach ($map as $new => $old) {
+      if (isset($record[$old])) {
+        $value = $record[$old];
+      }
+      else {
+        $value = NULL;
+      }
+
+      if ($value instanceof DateTime || $value instanceof DateTimeInterface) {
+        $value = $value->getTimestamp();
+      }
+
+      $replacement[$new] = $value;
+    }
+
+    $replacement['process'] = $this->processName;
+
+    return parent::format($replacement);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formatBatch(array $records) {
+    return array_map([$this, 'format'], $records);
+  }
+
+}

--- a/src/settings.php
+++ b/src/settings.php
@@ -1,5 +1,7 @@
 <?php
 
+use Monolog\Handler\ErrorLogHandler;
+
 // Set up Composer.
 require_once __DIR__ . '/../vendor/autoload.php';
 $conf['elife_composer_vendor_path'] = __DIR__ . '/../vendor';
@@ -37,4 +39,9 @@ require __DIR__ . '/../local.settings.php';
 // Turn Pathologic setting into the expected string.
 if (isset($conf['pathologic_local_paths'])) {
   $conf['pathologic_local_paths'] = implode("\n", $conf['pathologic_local_paths']);
+}
+
+// Use PHP's error log if Monolog hasn't been configured.
+if (!isset($conf['elife_monolog_handlers'])) {
+  $conf['elife_monolog_handlers'] = new ErrorLogHandler();
 }

--- a/tests/build/travis.local.settings.php
+++ b/tests/build/travis.local.settings.php
@@ -1,4 +1,9 @@
 <?php
 
+use Monolog\Handler\NullHandler;
+
 $conf['elife_article_markup_service_factory'] = '_elife_article_mock_markup_service';
 $conf['elife_node_binary'] = '%NODE_BIN%';
+
+// Disable logging as we're not reading it.
+$conf['elife_monolog_handlers'] = new NullHandler();


### PR DESCRIPTION
This sets up Monolog as disables DBLog. I've written a small custom module as the [Monolog module](https://www.drupal.org/project/monolog) doesn't really appear to support environment handlers customised by the environment, which is how we should use them (as opposed to having certain ones featurised then picking which one to use, as that's quite limiting).
