### PR TITLE
Fix compact person profile display in Safari

### DIFF
--- a/src/elife_profile/modules/custom/elife_person_profile/css/person-profile-compact.css
+++ b/src/elife_profile/modules/custom/elife_person_profile/css/person-profile-compact.css
@@ -31,6 +31,7 @@ div.panel-pane div.node.person-profile-compact {
   position: absolute;
   top: 50%;
   left: 50%;
+  -webkit-transform: translate(-50%, -50%);
   transform: translate(-50%, -50%);
 }
 
@@ -52,6 +53,7 @@ div.panel-pane div.node.person-profile-compact {
 .person-profile-compact__text {
   position: absolute;
   top: 50%;
+  -webkit-transform: translate(0, -50%);
   transform: translate(0, -50%);
   font-size: 1em;
   line-height: 1.1;


### PR DESCRIPTION
Safari currently requires the `-webkit-` prefix for CSS's `transform`, otherwise it ends up like:

<img width="177" alt="screen shot 2015-09-04 at 08 26 56" src="https://cloud.githubusercontent.com/assets/1784740/9678603/cf1655f2-52de-11e5-8069-0028ee5ed619.png">
