### PR TITLE
Unstable modules

### DIFF
--- a/src/elife_profile/elife_profile.info
+++ b/src/elife_profile/elife_profile.info
@@ -45,7 +45,6 @@ dependencies[] = countries
 dependencies[] = ctools
 dependencies[] = date
 dependencies[] = date_api
-dependencies[] = date_facets
 dependencies[] = date_popup
 dependencies[] = date_views
 dependencies[] = delta

--- a/src/elife_profile/elife_profile.make.yml
+++ b/src/elife_profile/elife_profile.make.yml
@@ -28,12 +28,6 @@ projects:
     version: '1.7'
   date:
     version: '2.8'
-  date_facets:
-    version: '1.x-dev'
-    download:
-      type: 'git'
-      url: 'http://git.drupal.org/project/date_facets.git'
-      revision: '9037608bc2736096b9e30d94e843958aab27e584'
   delta:
     version: '3.0-beta11'
   devel:

--- a/src/elife_profile/modules/custom/elife_search/elife_search.facetapi_defaults.inc
+++ b/src/elife_profile/modules/custom/elife_search/elife_search.facetapi_defaults.inc
@@ -102,10 +102,10 @@ function elife_search_facetapi_default_facet_settings() {
   $facet->searcher = 'search_api@elife_articles_index';
   $facet->realm = 'block';
   $facet->facet = 'field_elife_a_fpubdate';
-  $facet->enabled = TRUE;
+  $facet->enabled = FALSE;
   $facet->settings = array(
     'weight' => 0,
-    'widget' => 'date_range',
+    'widget' => 'facetapi_links',
     'filters' => array(),
     'active_sorts' => array(
       'indexed' => 'indexed',

--- a/src/elife_profile/modules/custom/elife_search/elife_search.info
+++ b/src/elife_profile/modules/custom/elife_search/elife_search.info
@@ -3,7 +3,6 @@ core = 7.x
 package = eLife
 version = 7.x-1.0
 project = elife_search
-dependencies[] = date_facets
 dependencies[] = elife_article
 dependencies[] = page_manager
 dependencies[] = search_api_facetapi

--- a/src/elife_profile/modules/custom/elife_search/elife_search.pages_default.inc
+++ b/src/elife_profile/modules/custom/elife_search/elife_search.pages_default.inc
@@ -564,29 +564,6 @@ function elife_search_default_page_manager_pages() {
   $display->content['new-ab3dc546-bdcf-4653-b8b0-b37c38a2f7ca'] = $pane;
   $display->panels['side_top'][0] = 'new-ab3dc546-bdcf-4653-b8b0-b37c38a2f7ca';
   $pane = new stdClass();
-  $pane->pid = 'new-c14b45a2-25f8-40de-bc35-ed74049b8bc5';
-  $pane->panel = 'side_top';
-  $pane->type = 'block';
-  $pane->subtype = 'facetapi-AVGMbjNIxhJvJepgV6biSs8slb14KUbc';
-  $pane->shown = TRUE;
-  $pane->access = array();
-  $pane->configuration = array(
-    'override_title' => 1,
-    'override_title_text' => 'Filter by publication date',
-    'override_title_heading' => 'h2',
-  );
-  $pane->cache = array();
-  $pane->style = array(
-    'settings' => NULL,
-  );
-  $pane->css = array();
-  $pane->extras = array();
-  $pane->position = 1;
-  $pane->locks = array();
-  $pane->uuid = 'c14b45a2-25f8-40de-bc35-ed74049b8bc5';
-  $display->content['new-c14b45a2-25f8-40de-bc35-ed74049b8bc5'] = $pane;
-  $display->panels['side_top'][1] = 'new-c14b45a2-25f8-40de-bc35-ed74049b8bc5';
-  $pane = new stdClass();
   $pane->pid = 'new-72547073-4e1e-497e-a577-d3aefef5d22e';
   $pane->panel = 'side_top';
   $pane->type = 'block';
@@ -604,11 +581,11 @@ function elife_search_default_page_manager_pages() {
   );
   $pane->css = array();
   $pane->extras = array();
-  $pane->position = 2;
+  $pane->position = 1;
   $pane->locks = array();
   $pane->uuid = '72547073-4e1e-497e-a577-d3aefef5d22e';
   $display->content['new-72547073-4e1e-497e-a577-d3aefef5d22e'] = $pane;
-  $display->panels['side_top'][2] = 'new-72547073-4e1e-497e-a577-d3aefef5d22e';
+  $display->panels['side_top'][1] = 'new-72547073-4e1e-497e-a577-d3aefef5d22e';
   $pane = new stdClass();
   $pane->pid = 'new-265eea17-9a1f-4b38-ae00-9bb213a9d744';
   $pane->panel = 'side_top';
@@ -636,11 +613,11 @@ function elife_search_default_page_manager_pages() {
   );
   $pane->css = array();
   $pane->extras = array();
-  $pane->position = 3;
+  $pane->position = 2;
   $pane->locks = array();
   $pane->uuid = '265eea17-9a1f-4b38-ae00-9bb213a9d744';
   $display->content['new-265eea17-9a1f-4b38-ae00-9bb213a9d744'] = $pane;
-  $display->panels['side_top'][3] = 'new-265eea17-9a1f-4b38-ae00-9bb213a9d744';
+  $display->panels['side_top'][2] = 'new-265eea17-9a1f-4b38-ae00-9bb213a9d744';
   $display->hide_title = PANELS_TITLE_FIXED;
   $display->title_pane = '0';
   $handler->conf['display'] = $display;


### PR DESCRIPTION
This adds a note to why an unstable version of a module is used, and removes the date_facet module as it's broken (see ELPP-221).
