### PR TITLE
Force HTTP/1.0 for the IsolatedSolrListener HTTP client

### DIFF
--- a/tests/behat/services.yml
+++ b/tests/behat/services.yml
@@ -11,5 +11,5 @@ services:
   elife.behat.solr_client:
     class: GuzzleHttp\Client
     arguments:
-      - { base_url: %elife.solr_uri% }
+      - { base_url: %elife.solr_uri%, defaults: { version: 1.0 } }
     public: false


### PR DESCRIPTION
I've been having trouble when running tests locally ('Failed to clear the Solr index', 'cURL error 56: Problem (2) in the Chunked-Encoded data'), which looks to be the same as http://www.supermind.org/blog/763/solved-curl-56-received-problem-2-in-the-chunky-parser. So, this forces HTTP to 1.0 for the client that calls the Solr API. Updating cURL might also fix the problem, but this should be safe.
