### PR TITLE
Disable XDebug on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ env:
     - PATH="$HOME/.composer/vendor/bin:$PATH"
 
 before_install:
+  - phpenv config-rm xdebug.ini
   - travis_retry composer self-update
 
 install:


### PR DESCRIPTION
Having read https://github.com/travis-ci/travis-ci/issues/1697 I'm wondering how much of an impact XDebug is having on our Travis builds.
