### PR TITLE
Use personal access token on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ env:
 
 before_install:
   - composer self-update
-  - composer config --global github-oauth.github.com $ELIFE_DEPLOY_USER_TOKEN
+  - composer config --global github-oauth.github.com 12345abcry
   - cat ~/.composer/auth.json
 
 install:


### PR DESCRIPTION
GitHub downloads are rate-limited, but are cacheable unlike the clone fallback. In the event that the Travis caches are cleared, which we have to do occasionally, it probably won't be able to download dependencies for a while, slowing down builds.

The solution is to use a personal access token, so I've added one for the elife-deploy-user as an environment variable.
