### PR TITLE
Add environments

### DIFF
--- a/create.sh
+++ b/create.sh
@@ -2,7 +2,29 @@
 set -e # all commands must pass
 
 SCRIPTPATH=$( cd $(dirname $0) ; pwd -P )
+DEV=true
+
+while true;
+do
+    case "$1" in
+      --no-dev)
+          DEV=false
+           shift
+           ;;
+      -*)
+          echo "Error: Unknown option: $1" >&2
+          exit 1
+          ;;
+      *)  # No more options
+          break
+          ;;
+    esac
+done
 
 cd "$SCRIPTPATH"
-./setup.sh
+if [ $DEV = true ] ; then
+    ./setup.sh
+else
+    ./setup.sh --no-dev
+fi
 ./install.sh

--- a/local.settings.php.example
+++ b/local.settings.php.example
@@ -16,6 +16,8 @@ $databases = [
     ],
 ];
 
+$conf['elife_environment'] = ELIFE_ENVIRONMENT_DEVELOPMENT;
+
 $conf['redis_client_host'] = '127.0.0.1';
 $conf['redis_client_port'] = 6379;
 

--- a/remake.sh
+++ b/remake.sh
@@ -2,11 +2,35 @@
 set -e # all commands must pass
 
 SCRIPTPATH=$( cd $(dirname $0) ; pwd -P )
+DEV=true
+
+while true;
+do
+    case "$1" in
+      --no-dev)
+          DEV=false
+           shift
+           ;;
+      -*)
+          echo "Error: Unknown option: $1" >&2
+          exit 1
+          ;;
+      *)  # No more options
+          break
+          ;;
+    esac
+done
 
 cd "$SCRIPTPATH"
 rm -rf ./src/elife_profile/libraries/
 rm -rf ./src/elife_profile/modules/contrib/
 rm -rf ./src/elife_profile/themes/contrib/
-drush make --no-core --concurrency=3 --no-recursion --contrib-destination=. ./src/elife_profile/elife_profile.make.yml ./src/elife_profile
-npm install --prefix ./src/elife_profile/libraries/elife-eif-schema/
-composer install --prefer-dist --no-interaction
+if [ $DEV = true ] ; then
+    drush make --no-core --concurrency=3 --no-recursion --contrib-destination=. ./src/elife_profile/elife_profile.make.dev.yml ./src/elife_profile
+    npm install --prefix ./src/elife_profile/libraries/elife-eif-schema/
+    composer install --prefer-dist --no-interaction
+else
+    drush make --no-core --concurrency=3 --no-recursion --contrib-destination=. ./src/elife_profile/elife_profile.make.yml ./src/elife_profile
+    npm install --prefix ./src/elife_profile/libraries/elife-eif-schema/
+    composer install --prefer-dist --no-interaction --no-dev --optimize-autoloader --classmap-authoritative
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -2,6 +2,24 @@
 set -e # all commands must pass
 
 SCRIPTPATH=$( cd $(dirname $0) ; pwd -P )
+DEV=true
+
+while true;
+do
+    case "$1" in
+      --no-dev)
+          DEV=false
+           shift
+           ;;
+      -*)
+          echo "Error: Unknown option: $1" >&2
+          exit 1
+          ;;
+      *)  # No more options
+          break
+          ;;
+    esac
+done
 
 cd "$SCRIPTPATH"
 if [ -d ./web/ ]; then
@@ -11,4 +29,8 @@ fi
 drush make ./src/drupal.make.yml ./web
 ln -s "../../src/elife_profile" "$SCRIPTPATH/web/profiles/"
 ln -s "../../../src/settings.php" "$SCRIPTPATH/web/sites/default/"
-./remake.sh
+if [ $DEV = true ] ; then
+    ./remake.sh
+else
+    ./remake.sh --no-dev
+fi

--- a/src/elife_profile/elife_profile.info
+++ b/src/elife_profile/elife_profile.info
@@ -9,7 +9,6 @@ exclusive = true
 dependencies[] = admin_menu
 dependencies[] = block
 dependencies[] = contextual
-dependencies[] = field_ui
 dependencies[] = file
 dependencies[] = image
 dependencies[] = list
@@ -19,17 +18,6 @@ dependencies[] = options
 dependencies[] = page_manager
 dependencies[] = path
 dependencies[] = taxonomy
-
-; Development modules.
-dependencies[] = admin_devel
-dependencies[] = context_ui
-dependencies[] = delta_ui
-dependencies[] = devel
-dependencies[] = ds_ui
-dependencies[] = field_validation_ui
-dependencies[] = module_builder
-dependencies[] = rules_admin
-dependencies[] = views_ui
 
 ; Migration modules.
 dependencies[] = migrate
@@ -136,6 +124,7 @@ dependencies[] = elife_collection
 dependencies[] = elife_config
 dependencies[] = elife_content_alerts
 dependencies[] = elife_early_careers
+dependencies[] = elife_environment
 dependencies[] = elife_footer
 dependencies[] = elife_front_matter
 dependencies[] = elife_header

--- a/src/elife_profile/elife_profile.install
+++ b/src/elife_profile/elife_profile.install
@@ -340,6 +340,8 @@ function elife_profile_install() {
   }
   // Disable migrate autoregistration.
   variable_set('migrate_disable_autoregistration', TRUE);
+
+  elife_environment_enable_environment_modules();
 }
 
 /**

--- a/src/elife_profile/elife_profile.make.dev.yml
+++ b/src/elife_profile/elife_profile.make.dev.yml
@@ -1,0 +1,14 @@
+includes:
+  - 'elife_profile.make.yml'
+
+projects:
+  devel:
+    version: '1.5'
+    patch:
+      - 'https://www.drupal.org/files/issues/1858318-devel-efq-debug-30.patch'
+  module_builder:
+    version: '2.x-dev' # no stable release available
+    download:
+      type: 'git'
+      url: 'http://git.drupal.org/project/module_builder.git'
+      revision: 'f0b3b384e592adee3c07aefbb1a318539cdb48f8'

--- a/src/elife_profile/elife_profile.make.yml
+++ b/src/elife_profile/elife_profile.make.yml
@@ -30,10 +30,6 @@ projects:
     version: '2.9'
   delta:
     version: '3.0-beta11'
-  devel:
-    version: '1.5'
-    patch:
-      - 'https://www.drupal.org/files/issues/1858318-devel-efq-debug-30.patch'
   diff:
     version: '3.2'
   ds:
@@ -114,12 +110,6 @@ projects:
     version: '2.8'
   migrate_extras:
     version: '2.5'
-  module_builder:
-    version: '2.x-dev' # no stable release available
-    download:
-      type: 'git'
-      url: 'http://git.drupal.org/project/module_builder.git'
-      revision: 'f0b3b384e592adee3c07aefbb1a318539cdb48f8'
   module_filter:
     version: '2.0'
   node_clone:

--- a/src/elife_profile/elife_profile.profile
+++ b/src/elife_profile/elife_profile.profile
@@ -222,3 +222,67 @@ function elife_profile_crumbs_get_info() {
 
   return $crumbs;
 }
+
+/**
+ * Returns the current environment.
+ *
+ * @return string
+ */
+function elife_environment() {
+  return variable_get('elife_environment', ELIFE_ENVIRONMENT_PRODUCTION);
+}
+
+/**
+ * Returns environment-specific modules.
+ *
+ * @param string $environment
+ *   Environment to check.
+ * @param bool $inverse
+ *   FALSE for modules required by this environment, TRUE for modules required
+ *   by other environments (excluding those also required by this environment).
+ *
+ * @return array
+ *   Modules.
+ */
+function elife_profile_environment_modules($environment, $inverse = FALSE) {
+  static $modules = [
+    ELIFE_ENVIRONMENT_PRODUCTION => [
+    ],
+    ELIFE_ENVIRONMENT_DEVELOPMENT => [
+      'admin_devel',
+      'context_ui',
+      'delta_ui',
+      'devel',
+      'ds_ui',
+      'field_ui',
+      'field_validation_ui',
+      'module_builder',
+      'rules_admin',
+      'update',
+      'views_ui',
+    ],
+    ELIFE_ENVIRONMENT_TESTING => [
+    ],
+  ];
+
+  if (!isset($modules[$environment])) {
+    throw new LogicException('Invalid environment');
+  }
+
+  if (!$inverse) {
+    return $modules[$environment];
+  }
+  else {
+    $filtered = [];
+
+    foreach ($modules as $this_environment => $environment_modules) {
+      if ($environment === $this_environment) {
+        continue;
+      }
+
+      $filtered = array_merge($filtered, $environment_modules);
+    }
+
+    return array_unique(array_diff($filtered, $modules[$environment]));
+  }
+}

--- a/src/elife_profile/modules/custom/elife_article/elife_article.module
+++ b/src/elife_profile/modules/custom/elife_article/elife_article.module
@@ -408,7 +408,7 @@ function elife_article_serializer() {
         $dispatcher->addSubscriber(new SubArticleSubscriber());
       })
       ->setCacheDir(variable_get('elife_cache_dir', sys_get_temp_dir()) . '/jms_serializer')
-      ->setDebug(!variable_get('elife_production', FALSE))
+      ->setDebug(ELIFE_ENVIRONMENT_PRODUCTION !== elife_environment())
       ->build();
   }
 

--- a/src/elife_profile/modules/custom/elife_environment/elife_environment.drush.inc
+++ b/src/elife_profile/modules/custom/elife_environment/elife_environment.drush.inc
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Implements hook_drush_command().
+ */
+function elife_environment_drush_command() {
+  $items['elife-environment-modules'] = [
+    'description' => dt('Enable/disable environment-specific modules'),
+  ];
+  return $items;
+}
+
+/**
+ * Command callback. Enables/disables modules for the current environment.
+ */
+function drush_elife_environment_elife_environment_modules() {
+  $enabled = elife_environment_enable_environment_modules();
+  $disabled = elife_environment_disable_environment_modules();
+
+  $flush_caches = FALSE;
+
+  $return = [];
+
+  if (empty($disabled)) {
+    $return[] = t('Nothing to disable');
+  }
+  else {
+    $return[] = t('Disabled: !modules', array('!modules' => implode(', ', $disabled)));
+    $flush_caches = TRUE;
+  }
+
+  if (empty($enabled)) {
+    $return[] = t('Nothing to enable');
+  }
+  else {
+    $return[] = t('Enabled: !modules', array('!modules' => implode(', ', $enabled)));
+    $flush_caches = TRUE;
+  }
+
+  if ($flush_caches) {
+    drupal_flush_all_caches();
+  }
+
+  return implode(PHP_EOL, $return);
+}

--- a/src/elife_profile/modules/custom/elife_environment/elife_environment.info
+++ b/src/elife_profile/modules/custom/elife_environment/elife_environment.info
@@ -1,0 +1,5 @@
+name = eLife: Environment
+description = Environment
+core = 7.x
+package = eLife
+version = 7.x-1.0

--- a/src/elife_profile/modules/custom/elife_environment/elife_environment.module
+++ b/src/elife_profile/modules/custom/elife_environment/elife_environment.module
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Enable modules required by this environment.
+ *
+ * @return array
+ *   Modules enabled.
+ */
+function elife_environment_enable_environment_modules() {
+  $enable = elife_profile_environment_modules(elife_environment(), TRUE);
+
+  $currently_enabled = system_list('module_enabled');
+
+  foreach ($enable as $key => $value) {
+    if (isset($currently_enabled[$value])) {
+      unset($enable[$key]);
+    }
+  }
+
+  if (!empty($enable)) {
+    if (!module_enable($enable, FALSE)) {
+      throw new RuntimeException(t('Failed to enable: !modules', ['!modules' => implode(', ', $enable)]));
+    }
+  }
+
+  return $enable;
+}
+
+/**
+ * Disable modules not required by this environment.
+ *
+ * @return array
+ *   Modules disabled.
+ */
+function elife_environment_disable_environment_modules() {
+  $disable = elife_profile_environment_modules(elife_environment(), FALSE);
+
+  $currently_enabled = system_list('module_enabled');
+
+  foreach ($disable as $key => $value) {
+    if (!isset($currently_enabled[$value])) {
+      unset($disable[$key]);
+    }
+  }
+
+  if (!empty($disable)) {
+    module_disable($disable, TRUE);
+  }
+
+  return $disable;
+}

--- a/src/settings.php
+++ b/src/settings.php
@@ -2,12 +2,13 @@
 
 use Monolog\Handler\ErrorLogHandler;
 
+const ELIFE_ENVIRONMENT_PRODUCTION = 'production';
+const ELIFE_ENVIRONMENT_DEVELOPMENT = 'development';
+const ELIFE_ENVIRONMENT_TESTING = 'testing';
+
 // Set up Composer.
 require_once __DIR__ . '/../vendor/autoload.php';
 $conf['elife_composer_vendor_path'] = __DIR__ . '/../vendor';
-
-// Define the environment.
-$conf['elife_production'] = FALSE;
 
 // Don't allow modules to be added/updated through the UI.
 $conf['allow_authorize_operations'] = FALSE;
@@ -55,6 +56,7 @@ if (extension_loaded('redis')) {
 // - $databases
 // - $conf['redis_client_host'] OR $conf['redis_client_socket']
 // - $conf['imagemagick_convert']
+// - $conf['elife_environment']
 //
 // It may also contain any custom configuration required by this environment.
 require __DIR__ . '/../local.settings.php';

--- a/tests/behat/services.yml
+++ b/tests/behat/services.yml
@@ -1,5 +1,10 @@
 services:
 
+  elife.behat.listener.environment:
+    class: eLife\Behat\EnvironmentListener
+    tags:
+      - { name: event_dispatcher.subscriber }
+
   elife.behat.listener.isolated_solr:
     class: eLife\Behat\IsolatedSolrListener
     arguments:

--- a/tests/behat/src/EnvironmentListener.php
+++ b/tests/behat/src/EnvironmentListener.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace eLife\Behat;
+
+use eLife\IsolatedDrupalBehatExtension\Event\WritingSiteSettingsFile;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface as EventSubscriber;
+
+final class EnvironmentListener implements EventSubscriber {
+  public static function getSubscribedEvents() {
+    return [
+      WritingSiteSettingsFile::NAME => 'onWritingSiteSettingsFile',
+    ];
+  }
+
+  /**
+   * @param WritingSiteSettingsFile $event
+   */
+  public function onWritingSiteSettingsFile(WritingSiteSettingsFile $event) {
+    $event->addSettings('$conf["elife_environment"] = ELIFE_ENVIRONMENT_TESTING;');
+  }
+}

--- a/update.sh
+++ b/update.sh
@@ -8,5 +8,6 @@ drush variable-set --exact maintenance_mode 1 --yes
 drush registry-rebuild
 drush updatedb --yes
 drush features-revert-all --yes
+drush elife-environment-modules
 if [[ $(drush php-eval "print node_access_needs_rebuild()") == "1" ]]; then drush node-access-rebuild; fi;
 drush variable-set --exact maintenance_mode 0 --yes


### PR DESCRIPTION
Designed to fix ELPP-260.

It adds two separate options for defining the environment:
1. The setup scripts have a `--no-dev` option which will stop dev dependencies being downloaded (and Composer's autoloader is optimised etc, ie for production use)
2. The `elife_environment` variable is made available, which lets Drupal know what environment it's running in (one of `ELIFE_ENVIRONMENT_PRODUCTION`, `ELIFE_ENVIRONMENT_DEVELOPMENT` or `ELIFE_ENVIRONMENT_TESTING`)

Drupal now enables/disables modules as appropriate (eg the dev environment has development modules enabled). This might speed up test runs slightly as less modules are enabled too.

Ping @nlisgo for review.
