### PR TITLE
Block access to subpaths

### DIFF
--- a/src/elife_profile/modules/custom/elife_collection/elife_collection.pages_default.inc
+++ b/src/elife_profile/modules/custom/elife_collection/elife_collection.pages_default.inc
@@ -326,6 +326,20 @@ function elife_collection_default_page_manager_pages() {
     'css' => '',
     'contexts' => array(),
     'relationships' => array(),
+    'access' => array(
+      'plugins' => array(
+        0 => array(
+          'name' => 'path_visibility',
+          'settings' => array(
+            'visibility_setting' => '1',
+            'paths' => 'collections',
+          ),
+          'context' => 'empty',
+          'not' => FALSE,
+        ),
+      ),
+      'logic' => 'and',
+    ),
   );
   $display = new panels_display();
   $display->layout = 'elife_collection';

--- a/src/elife_profile/modules/custom/elife_front_matter/elife_front_matter.pages_default.inc
+++ b/src/elife_profile/modules/custom/elife_front_matter/elife_front_matter.pages_default.inc
@@ -44,6 +44,16 @@ function elife_front_matter_default_page_manager_pages() {
     'css' => '',
     'contexts' => array(),
     'relationships' => array(),
+    'access' => array(
+      'plugins' => array(
+        0 => array(
+          'name' => 'front',
+          'settings' => NULL,
+          'not' => FALSE,
+        ),
+      ),
+      'logic' => 'and',
+    ),
   );
   $display = new panels_display();
   $display->layout = 'elife_omega_coverpage';

--- a/src/elife_profile/modules/custom/elife_news/elife_news.pages_default.inc
+++ b/src/elife_profile/modules/custom/elife_news/elife_news.pages_default.inc
@@ -338,6 +338,20 @@ function elife_news_default_page_manager_pages() {
     'contexts' => array(),
     'relationships' => array(),
     'name' => 'panel',
+    'access' => array(
+      'plugins' => array(
+        0 => array(
+          'name' => 'path_visibility',
+          'settings' => array(
+            'visibility_setting' => '1',
+            'paths' => 'elife-news',
+          ),
+          'context' => 'empty',
+          'not' => FALSE,
+        ),
+      ),
+      'logic' => 'and',
+    ),
   );
   $display = new panels_display();
   $display->layout = 'elife_article';

--- a/src/elife_profile/modules/custom/elife_search/elife_search.pages_default.inc
+++ b/src/elife_profile/modules/custom/elife_search/elife_search.pages_default.inc
@@ -500,6 +500,20 @@ function elife_search_default_page_manager_pages() {
     'css' => '',
     'contexts' => array(),
     'relationships' => array(),
+    'access' => array(
+      'plugins' => array(
+        0 => array(
+          'name' => 'path_visibility',
+          'settings' => array(
+            'visibility_setting' => '1',
+            'paths' => 'elife/search',
+          ),
+          'context' => 'empty',
+          'not' => FALSE,
+        ),
+      ),
+      'logic' => 'and',
+    ),
   );
   $display = new panels_display();
   $display->layout = 'elife_article';

--- a/tests/behat/features/collections.feature
+++ b/tests/behat/features/collections.feature
@@ -242,6 +242,10 @@ Feature: Collections
     Then I should see text matching "Algoriphagus"
     Then I should see 2 "h2.collection-teaser__title" element
 
+  Scenario: Sub-paths aren't accessible
+    When I go to "/collections/foo"
+    Then the response status code should be 404
+
   Scenario: Collections with related content
     When "elife_person_profile" content:
       | field_elife_pp_first_name | field_elife_pp_last_name | field_elife_pp_type |

--- a/tests/behat/features/collections_heroblock.feature
+++ b/tests/behat/features/collections_heroblock.feature
@@ -162,22 +162,6 @@ Feature: In order to represent 'Collections'
           ]
      """
 
-  Scenario: Creating and verifying Hero block only
-    Given I am logged in as a user with the "access administration menu,access content,create elife_hero_block content,bypass rh_node" permissions
-    And I am on "/node/add/elife-hero-block"
-    Then I should see "Create eLife Hero Block"
-    Then I fill in "Title" with "Hero block - Algoriphagus"
-    Then I fill in "edit-field-elife-h-sub-title-und-0-value" with "Sub-title for Algoriphagus"
-    Then I fill in "Appears on" with "collections/algoriphagus"
-    When I attach the file "test.jpg" to "edit-field-elife-h-image-und-0-upload"
-    Then I select the radio button "Dark" with the id "edit-field-elife-h-image-colour-und-dark"
-    And I press "Save"
-    And I should see "Hero block - Algoriphagus"
-    And I should see "Sub-title for Algoriphagus"
-    And I am on "/collections/algoriphagus"
-    And I should see "Hero block - Algoriphagus"
-    And I should see "Sub-title for Algoriphagus"
-
   Scenario: Verify Hero block on a collections page
     Given I am logged in as a user with the "access administration menu,access content,create elife_hero_block content" permissions
     When "elife_person_profile" content:
@@ -227,6 +211,9 @@ Feature: In order to represent 'Collections'
 
   Scenario: Hero block for collections without articles
     Given I am logged in as a user with the "administrator" role
+    And "elife_collection" content:
+      | title        | field_elife_c_articles                                                         | field_elife_c_curators               |
+      | Algoriphags2 | 05204: Article 11 for Collections test, 05205: Article 13 for Collections test | FirstName LastName (Executive Staff) |
     When "elife_person_profile" content:
       | field_elife_pp_first_name | field_elife_pp_last_name | field_elife_pp_type |
       | FirstName                 | LastName                 | Executive Staff     |
@@ -238,9 +225,6 @@ Feature: In order to represent 'Collections'
     When I attach the file "test.jpg" to "edit-field-elife-h-image-und-0-upload"
     Then I select the radio button "Dark" with the id "edit-field-elife-h-image-colour-und-dark"
     And I press "Save"
-    When "elife_collection" content:
-      | title        | field_elife_c_articles                                                         | field_elife_c_curators               |
-      | Algoriphags2 | 05204: Article 11 for Collections test, 05205: Article 13 for Collections test | FirstName LastName (Executive Staff) |
     And I am on "/collections/algoriphags2"
     And I should see "Hero block - Algoriphagus"
     And I should see "Collection with no articles"

--- a/tests/behat/features/front_matter.feature
+++ b/tests/behat/features/front_matter.feature
@@ -32,6 +32,10 @@ Feature: Front Matter
     And I should be on "content/4/e05224v1"
     And I should see "VOR 05224 v1" in the "h1" element
 
+  Scenario: Sub-paths aren't accessible
+    When I go to "/cover/foo"
+    Then the response status code should be 404
+
   @api
   Scenario: Load cover item to homepage referencing a podcast
     Given "elife_podcast" content:

--- a/tests/behat/features/news.feature
+++ b/tests/behat/features/news.feature
@@ -10,6 +10,10 @@ Feature: News
     And I should see "No news articles are currently available." in the ".content .main-wrapper" element
     And I should not see a ".content .sidebar-wrapper" element
 
+  Scenario: Sub-paths aren't accessible
+    When I go to "/elife-news/foo"
+    Then the response status code should be 404
+
   Scenario: News article without any categories
     Given "elife_news_article" content:
       | title | field_elife_n_text |

--- a/tests/behat/features/search_page.feature
+++ b/tests/behat/features/search_page.feature
@@ -12,6 +12,10 @@ Feature: Search
     When I click the ".header__list li a.header__list_link.header__list_link--search" element
     Then the url should match "/elife/search"
 
+  Scenario: Sub-paths aren't accessible
+    When I go to "/elife/search/foo"
+    Then the response status code should be 404
+
   Scenario: Appropriate title and input box for the Search page
     Given I am on "/elife/search"
     Then the response status code should be 200


### PR DESCRIPTION
This fixes the behaviour of https://groups.drupal.org/node/13878, so that paths such as `/elife/search/foo` aren't accessible. We don't have to worry about normal Drupal paths as we're using path aliases and Rabbit Hole.

We'll have to remember to do the same for any future Panels pages.
