### PR TITLE
Reverse person profile names

### DIFF
--- a/src/elife_profile/modules/custom/elife_person_profile/elife_person_profile.strongarm.inc
+++ b/src/elife_profile/modules/custom/elife_person_profile/elife_person_profile.strongarm.inc
@@ -21,7 +21,7 @@ function elife_person_profile_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'auto_entitylabel_pattern_node_elife_person_profile';
-  $strongarm->value = '[node:field-elife-pp-last-name], [node:field-elife-pp-first-name] ([node:field-elife-pp-type])';
+  $strongarm->value = '[node:field-elife-pp-first-name] [node:field-elife-pp-last-name] ([node:field-elife-pp-type])';
   $export['auto_entitylabel_pattern_node_elife_person_profile'] = $strongarm;
 
   $strongarm = new stdClass();


### PR DESCRIPTION
`elife_person_profile` titles are currently in the format 'Last Name, First Name (Type)' for ease of sorting in the admin interface. The Drupal Behat extension can't handle the comma though (see https://github.com/jhedstrom/drupalextension/pull/215). Until that is fixed, this reverse the order.
