### PR TITLE
Update article doi block display

### DIFF
--- a/src/elife_profile/modules/custom/elife_templates/plugins/content_types/elife_article_doi.inc
+++ b/src/elife_profile/modules/custom/elife_templates/plugins/content_types/elife_article_doi.inc
@@ -99,6 +99,7 @@ function elife_article_doi_render($subtype, $conf, $args, $context) {
             }
 
             $output .= '<span class="elife-article-correction">';
+            $output .= '<i class="icon-exclamation-sign"></i>';
             $output .= l($label, 'node/' . $related_article->{$related_article->related_to_endpoint . '_article_ver_nid'});
             $output .= '</span>';
           }

--- a/src/elife_profile/themes/custom/elife/css/elife-text.css
+++ b/src/elife_profile/themes/custom/elife/css/elife-text.css
@@ -314,12 +314,11 @@ h2.snippet-title {
 		margin-top: 12px;
 	}
 
-.pane-elife-doi,
-.elife-doi-epubdate,
-.elife-doi-cite-as {
-	font-size: 0.86rem;
-	line-height: 1.125rem;
+.pane-elife-article-doi {
+	font-size: 0.86em;
+	line-height: 1.5;
 }
+
 .label.elife-doi-pre-label,
 .label.elife-doi-epubdate-label,
 .label.elife-doi-cite-as-label {

--- a/src/elife_profile/themes/custom/elife/css/global.css
+++ b/src/elife_profile/themes/custom/elife/css/global.css
@@ -1607,16 +1607,16 @@ a.logo-wt {
 .pane-elife-article-doi .highwire-doi-epubdate,
 .pane-elife-article-doi .highwire-doi-cite-as,
 .pane-elife-article-doi .elife-article-correction,
-.pane-elife-article-doi .elife-article-retraction
+.pane-elife-article-doi .elife-article-retraction,
 .pane-elife-article-doi .elife-article-addendum {
   display: block;
 }
 
-.pane-elife-article-doi .elife-article-corrections {
+.pane-elife-article-doi .elife-article-correction {
   float: right;
-  font-size: 1.1em;
 }
-.pane-elife-article-doi .elife-article-corrections a {
+
+.pane-elife-article-doi .elife-article-correction a {
   margin-left: 5px;
 }
 


### PR DESCRIPTION
Includes fixing correction link display, and fixing a preexisting css syntax error (missing comma).
