### PR TITLE
Style article sidebar's related items

### DIFF
--- a/src/elife_profile/modules/custom/elife_front_matter/css/cover.css
+++ b/src/elife_profile/modules/custom/elife_front_matter/css/cover.css
@@ -59,6 +59,22 @@ body {
   float: left;
 }
 
+/* Specific definitions for the article impact statement. Uses generic sup/sub. */
+/* Avenir italic styles -- em & nlm-italic */
+/* Light weight */
+.author-impact-statement em,
+.author-impact-statement .nlm-italic {
+  font-family: 'AvenirLTW01-35LightObli', 'Avenir LT W01 35 Light', Helvetica, Arial, Verdana, sans-serif;
+  font-style: normal;
+}
+
+/* Specific definitions for the article title */
+.elife-article-citation .elife-cite-title em,
+.elife-article-citation .elife-cite-title .nlm-italic {
+  font-family: 'AvenirLTW01-45BookObliq', 'Avenir LT W01 45 Book', Helvetica, Arial, Verdana, sans-serif;
+  font-style: normal;
+}
+
 /* Utility styles */
 .off-screen {
   /* Conceal, but don't remove from DOM */
@@ -624,6 +640,33 @@ a.home-article-listing__list-item__display-channel {
   border-radius: 0.5em;
   background-color: #273b81;
   color: #fff;
+}
+
+/* a.home-article-listing__list-item__title not easily injected into markup so targeting link using existing markup. */
+.home-article-listing__list-item__text_wrapper .elife-cite-linked-title {
+  display: block;
+  margin-bottom: 0.6em;
+  padding: 0.1em 0 0.2em 0;
+  -webkit-transition: color 75ms linear;
+  -moz-transition: color 75ms linear;
+  -o-transition: color 75ms linear;
+  transition: color 75ms linear;
+  color: #273b81;
+  font-size: 1.375em;
+  line-height: 1.25em;
+  font-family: 'Avenir LT W01 45 Book', 'Avenir LT 45 Book', Helvetica, Arial, Verdana, sans-serif;
+}
+
+.home-article-listing__list-item__text_wrapper .elife-cite-linked-title:link,
+.home-article-listing__list-item__text_wrapper .elife-cite-linked-title:visited {
+  color: #273b81;
+}
+
+.home-article-listing__list-item__text_wrapper .elife-cite-linked-title:hover,
+.home-article-listing__list-item__text_wrapper .elife-cite-linked-title:focus,
+.home-article-listing__list-item__text_wrapper .elife-cite-linked-title:active {
+  text-decoration: none;
+  color: #6d6e70;
 }
 
 .home-article-listing__list-item__about {

--- a/src/elife_profile/themes/custom/elife/css/elife-default.css
+++ b/src/elife_profile/themes/custom/elife/css/elife-default.css
@@ -550,7 +550,7 @@ ul.elife-article-categories li a {
   margin-bottom:0;
 }
 .elife-reflink-main .elife-reflink-authors,
-.highwire-article-citation .highwire-cite-authors {
+.elife-article-citation .highwire-cite-authors {
 	line-height: 1.3em;
 }
 .elife-reflink-author a {

--- a/src/elife_profile/themes/custom/elife/css/elife-text.css
+++ b/src/elife_profile/themes/custom/elife/css/elife-text.css
@@ -595,19 +595,19 @@ div.highwire-markup .fig-caption p .supplementary-material .supplementary-materi
 
 /* eLife Citations, Reflinks Citations */
 .elife-reflink-main .elife-reflink-title,
-.highwire-article-citation .highwire-cite-title {
+.elife-article-citation .elife-cite-title {
 	font-family: 'Avenir LT W01 85 Heavy', sans-serif;
 	font-size: 1.15em; /* ~16px */
 	line-height: 1.13em; /* ~18px */
 }
 
 .elife-reflink-main .elife-reflink-authors,
-.highwire-article-citation .highwire-cite-authors {
+.elife-article-citation .highwire-cite-authors {
 	font-family: 'Avenir LT W01 35 Light', Helvetica, Arial, Verdana, sans-serif;
 	/*line-height: 1.3em; */ /* Moved to media queries*/
 }
 
-.highwire-article-citation .highwire-cite-impact-statement {
+.elife-article-citation .highwire-cite-impact-statement {
 	line-height: 1.4em;
 }
 
@@ -616,30 +616,31 @@ div.highwire-markup .fig-caption p .supplementary-material .supplementary-materi
 	line-height: 1.45em; /* 16px */
 }
 
-.highwire-article-citation .highwire-cite-doi,
-.highwire-article-citation .highwire-cite-categories-date,
-.highwire-article-citation .elife-citation-elife-small .highwire-cite-categories {
+.elife-article-citation .highwire-cite-doi,
+.elife-article-citation .highwire-cite-categories-date,
+.elife-article-citation .elife-citation-elife-small .elife-cite-categories {
 	font-size: 0.86em; /* ~12px */
 	line-height: 1.33em;
 }
 
-.highwire-article-citation .elife-citation-elife-large .highwire-cite-categories-date { 
+.elife-article-citation .elife-citation-elife-large .highwire-cite-categories-date { 
 	line-height: 1.5em; 
 }
 
-.highwire-article-citation .highwire-cite-doi,
-.highwire-article-citation .highwire-cite-categories li.active,
-.highwire-article-citation .highwire-cite-date {
+.elife-article-citation .highwire-cite-doi,
+.elife-article-citation .elife-cite-categories li.active,
+.elife-article-citation .highwire-cite-date {
 	font-style: italic;
 }
 
 /* Small style citations */
-.highwire-article-citation .elife-citation-elife-small .highwire-cite-title {
+.elife-article-citation .elife-citation-elife-small .elife-cite-title {
 	font-size: 1em;
 	line-height: 1.29em; 
 }
 
-.highwire-article-citation .elife-citation-elife-small .highwire-cite-authors {
+.elife-article-citation .elife-citation-elife-small .elife-cite-authors {
+	font-family: 'Avenir LT W01 35 Light',Helvetica,Arial,Verdana,sans-serif;
 	font-size: 0.93em; /* 13px */
 	line-height: 1.23em;
 }
@@ -688,8 +689,8 @@ ul.panels-ajax-tab .nlm-italic,
 .elife-searchlist-pagerbar-count .nlm-italic,
 .elife-reflink-main .elife-reflink-authors em,
 .elife-reflink-main .elife-reflink-authors .nlm-italic,
-.highwire-article-citation .highwire-cite-authors em,
-.highwire-article-citation .highwire-cite-authors .nlm-italic {
+.elife-article-citation .highwire-cite-authors em,
+.elife-article-citation .highwire-cite-authors .nlm-italic {
 	font-family: 'AvenirLTW01-35LightObli', sans-serif;
 	font-style: normal;
 }
@@ -717,8 +718,8 @@ div.highwire-markup .table-caption span.table-label .nlm-italic,
 .elife-searchlist-sortby .elife-searchlist-label .nlm-italic,
 .elife-reflink-main .elife-reflink-title em, 
 .elife-reflink-main .elife-reflink-title .nlm-italic,
-.highwire-article-citation .highwire-cite-title em, 
-.highwire-article-citation .highwire-cite-title .nlm-italic {
+.elife-article-citation .elife-cite-title em, 
+.elife-article-citation .elife-cite-title .nlm-italic {
 	font-family: 'AvenirLTW01-85HeavyObli', sans-serif;
 	font-style: normal;
 }

--- a/src/elife_profile/themes/custom/elife/css/global.css
+++ b/src/elife_profile/themes/custom/elife/css/global.css
@@ -100,8 +100,16 @@ ol.inline li {
   padding: 0 0.5em;
 }
 
-  .highwire-article-citation-list ul { padding-left: 0; }
+.elife-related-articles-list {
+  margin-left: 0;
+  padding-left: 0;
+}
 
+/* Another specificity war (sigh). */
+ul.elife-related-articles-list li {
+  margin-bottom: 0;
+  margin-left: 0;
+}
 
 /* Other text elements */
 blockquote {
@@ -2062,7 +2070,7 @@ img.elife-embed-fragment-image {
     margin:.3em 0;
   }
   .elife-reflink-main .elife-reflink-authors,
-  .highwire-article-citation .highwire-cite-authors {
+  .elife-article-citation .highwire-cite-authors {
     line-height: 1.8em;
   }
   .elife-reflink-author a {
@@ -3087,78 +3095,74 @@ img.elife-embed-fragment-image {
 	}
 
 	/* eLife Citation Styles */
-	.highwire-article-citation .highwire-cite {
+	.elife-article-citation .elife-cite {
 		clear: both;
 		margin-bottom: 30px;
 	}
 
-	.highwire-article-citation-list ul li {
-		margin-bottom: 0;
-	}
-
-	.highwire-article-citation .highwire-cite > div {
+	.elife-article-citation .elife-cite > div {
 		margin-bottom: 5px;
 	}
 
-	.highwire-article-citation .highwire-cite-ec {
+	.elife-article-citation .highwire-cite-ec {
 		float: left;
 		filter: alpha(opacity=50);
 		margin: 1px 8px 0 2px;
 		opacity: 0.5;
 	}
 
-	.highwire-article-citation .highwire-cite-categories .elife-citation-categories {
+	.elife-article-citation .elife-cite-categories .elife-citation-categories {
 		display: inline-block;
 		margin-bottom: 0;
 		padding-top: 0;
 	}
 
-	.highwire-article-citation .highwire-cite-impact-statement {
+	.elife-article-citation .highwire-cite-impact-statement {
 		margin: 5px 0;
 	}
 
-	.highwire-article-citation .elife-citation-elife-small .highwire-cite-categories li {
+	.elife-article-citation .elife-citation-elife-small .elife-cite-categories li {
 		display: inline-block;
 		margin-bottom: 0;
 	}
 
-	.highwire-article-citation .elife-citation-elife-small .highwire-cite-categories .elife-citation-categories li {
+	.elife-article-citation .elife-citation-elife-small .elife-cite-categories .elife-citation-categories li {
 		margin-bottom: 5px;
 	}
 
-	.highwire-article-citation .highwire-cite-categories li,
-	.highwire-article-citation .highwire-cite-categories + .highwire-cite-date {
+	.elife-article-citation .elife-cite-categories li,
+	.elife-article-citation .elife-cite-categories + .highwire-cite-date {
 		margin-left: 0;
 		margin-right: 0;
 		padding: 0;
 	}
-		.highwire-article-citation .highwire-cite-categories li:after,
-		.highwire-article-citation .highwire-cite-categories + .highwire-cite-date:before {
+		.elife-article-citation .elife-cite-categories li:after,
+		.elife-article-citation .elife-cite-categories + .highwire-cite-date:before {
 			color: #c8c9cb;
 			content: "\2014";
 			margin-left: 8px;
 			margin-right: 8px;
 		}
 
-		.highwire-article-citation .elife-citation-elife-small .highwire-cite-categories li:after,
-		.highwire-article-citation .elife-citation-elife-small .highwire-cite-categories + .highwire-cite-date:before {
+		.elife-article-citation .elife-citation-elife-small .elife-cite-categories li:after,
+		.elife-article-citation .elife-citation-elife-small .elife-cite-categories + .highwire-cite-date:before {
 			margin-left: 5px;
 			margin-right: 5px;
 		}
 
-	.highwire-article-citation .highwire-cite-categories li.last:after,
-	.highwire-article-citation .elife-citation-elife-small .highwire-cite-categories li.last:after {
+	.elife-article-citation .elife-cite-categories li.last:after,
+	.elife-article-citation .elife-citation-elife-small .elife-cite-categories li.last:after {
 		content: none;
 		margin-right: 0;
 		margin-left: 0;
 	}
 
-	.highwire-article-citation .highwire-cite-categories li a {
+	.elife-article-citation .elife-cite-categories li a {
 		color: #6d6e70;
 		font-style: italic;
 	}
 
-  .highwire-article-citation .highwire-cite-manuscript {
+  .elife-article-citation .highwire-cite-manuscript {
     color: #22A0D8;
     font-style: normal;
     text-transform: uppercase;
@@ -3166,7 +3170,7 @@ img.elife-embed-fragment-image {
   }
 
   /* Content type link colors */
-  .highwire-article-citation  .highwire-cite-categories a.citation-cat-display-channel {
+  .elife-article-citation  .elife-cite-categories a.category-display-channel {
     font-style: normal;
     background: #273b81;
     color: #fff;
@@ -3187,16 +3191,16 @@ img.elife-embed-fragment-image {
 
   /* bottom padding needs to be smaller for mozilla */
   @-moz-document url-prefix() {
-    .highwire-article-citation  .highwire-cite-categories a.citation-cat-display-channel { padding-bottom: 0.2em; }
+    .elife-article-citation  .elife-cite-categories a.category-display-channel { padding-bottom: 0.2em; }
   }
 
   /* Highwire Striking Image */
-  .highwire-article-citation .highwire-cite-striking-image {
+  .elife-article-citation .highwire-cite-striking-image {
     display: block;
     float: left;
   }
 
-  .highwire-article-citation .highwire-cite-striking-image a {
+  .elife-article-citation .highwire-cite-striking-image a {
     margin: 0 10px 10px 0;
     border: 1px solid #dfdddd;
     width: 60px;
@@ -3205,56 +3209,56 @@ img.elife-embed-fragment-image {
     text-align: center;
   }
 
-  .highwire-article-citation .highwire-cite-striking-image a:hover {
+  .elife-article-citation .highwire-cite-striking-image a:hover {
     border-color: #22a0d8;
   }
 
-  .highwire-article-citation .elife-citation-elife-striking-image-true .highwire-cite-body {
+  .elife-article-citation .elife-citation-elife-striking-image-true .highwire-cite-body {
     margin-left: 72px;
   }
 
   /* Research Articles = dark blue */
-  .highwire-cite-categories a.citation-cat-display-channel.research-article {
+  .elife-cite-categories a.category-display-channel.research-article {
     background-color: #273b81;
   }
 
   /* Research Advances = dark blue */
-  .highwire-cite-categories a.citation-cat-display-channel.research-advance {
+  .elife-cite-categories a.category-display-channel.research-advance {
     background-color: #273b81;
   }
 
   /* Registered reports = dark blue */
-  .highwire-cite-categories a.citation-cat-display-channel.registered-report {
+  .elife-cite-categories a.category-display-channel.registered-report {
     background-color: #273b81;
   }
 
   /* Replication studies = dark blue */
-  .highwire-cite-categories a.citation-cat-display-channel.replication-study {
+  .elife-cite-categories a.category-display-channel.replication-study {
     background-color: #273b81;
   }
 
   /* Tools and resources = dark blue */
-  .highwire-cite-categories a.citation-cat-display-channel.tools-and-resources {
+  .elife-cite-categories a.category-display-channel.tools-and-resources {
     background-color: #273b81;
   }
 
   /* Short Reports = dark blue */
-  .highwire-cite-categories a.citation-cat-display-channel.short-report {
+  .elife-cite-categories a.category-display-channel.short-report {
     background-color: #273b81;
   }
 
   /* Editorials = medium blue */
-  .highwire-cite-categories a.citation-cat-display-channel.editorial {
+  .elife-cite-categories a.category-display-channel.editorial {
     background-color: #0961ab;
   }
 
   /* Insights = light green */
-  .highwire-cite-categories a.citation-cat-display-channel.insight {
+  .elife-cite-categories a.category-display-channel.insight {
     background-color: #629f43;
   }
 
   /* Features = red */
-  .highwire-cite-categories a.citation-cat-display-channel.feature-article {
+  .elife-cite-categories a.category-display-channel.feature-article {
     background-color: #cf0c4e;
   }
 


### PR DESCRIPTION
Note that the background colour of the element describing the article type 'lozenge', carrying the css class 'category-display-channel' will always be default dark blue until the todo at line 1570 of elife-article.module is implemented ('add class for specific display channel'). 
