### PR TITLE
Remove CSS bullets from .list-simple as not required

### DIFF
--- a/src/elife_profile/themes/custom/elife/css/global.css
+++ b/src/elife_profile/themes/custom/elife/css/global.css
@@ -3736,3 +3736,7 @@ ul.links.hidden-small {
     max-width: 100%;
     height: auto;
 }
+
+.list-simple {
+  list-style: none;
+}


### PR DESCRIPTION
The list bullet symbols are included as bare characters in the XML.
