### PR TITLE
Hide jump menu when there's no main text content

### DIFF
--- a/src/elife_profile/modules/custom/elife_templates/plugins/content_types/elife_article_jumpto.inc
+++ b/src/elife_profile/modules/custom/elife_templates/plugins/content_types/elife_article_jumpto.inc
@@ -17,6 +17,7 @@ $plugin = array(
  */
 function elife_article_jumpto_render($subtype, $conf, $args, &$context) {
   $article_version = $context->data;
+  $block = new stdClass();
 
   /* @var EntityDrupalWrapper $ewrapper */
   if ($ewrapper = entity_metadata_wrapper('node', $article_version)) {
@@ -47,17 +48,17 @@ function elife_article_jumpto_render($subtype, $conf, $args, &$context) {
             $links['article']['children']['main-text']['children'][] = elife_article_jumpto_link($h3->nodeValue, $h3->parentNode->getAttribute('id'), 'jnl_elife_article_article');
           }
           libxml_clear_errors();
-        }
-        $block = new stdClass();
-        $block->content = '<div class="elife-jumpto">';
-        $block->content .= theme('item_list', array('items' => $links));
-        $block->content .= '</div>';
 
-        drupal_add_js(drupal_get_path('module', 'elife_templates') . '/js/elife_article_jumpto.js');
-        return $block;
+          $block->content = '<div class="elife-jumpto">';
+          $block->content .= theme('item_list', array('items' => $links));
+          $block->content .= '</div>';
+  
+          drupal_add_js(drupal_get_path('module', 'elife_templates') . '/js/elife_article_jumpto.js');
+        }
       }
     }
   }
+  return $block;
 }
 
 function elife_article_jumpto_link($name, $anchor, $tab, $class = NULL, $path = '', $attributes = array()) {

--- a/src/elife_profile/themes/custom/elife/css/global.css
+++ b/src/elife_profile/themes/custom/elife/css/global.css
@@ -2820,13 +2820,17 @@ img.elife-embed-fragment-image {
   .article-tools__link--pdf-figures {
     background-position: 0 -120px;
   }
-    .sharethis-wrapper .stButton, .elife-share-wrapper .stButton, #article-jumplinks-anchor-region .stButton {
+    .sharethis-wrapper .stButton, .elife-share-wrapper .stButton, .article-jumplinks-anchor-region .stButton {
         margin: 0;
     }
 
-    #article-jumplinks-anchor-region .pane-elife-article-share .pane-title {
+    .article-jumplinks-anchor-region .pane-elife-article-share .pane-title {
         display: none;
     }
+  /* TODO - dm - introduce Modernizr so can use no-js class instead for better legacy support */
+  html:not(.js) .article-jumplinks-anchor-region {
+    display: none;
+  }
 
 	/* API expanded content */
 	#api_box {

--- a/src/elife_profile/themes/custom/elife/panels/layouts/elife_article/elife-article.tpl.php
+++ b/src/elife_profile/themes/custom/elife/panels/layouts/elife_article/elife-article.tpl.php
@@ -52,7 +52,7 @@
 				  </div>
 				<?php endif; ?>
 				<?php if ($content['side_bottom']): ?>
-					<div class="panel-panel panel-region-sidebar-bottom" id="article-jumplinks-anchor-region">
+					<div class="panel-panel panel-region-sidebar-bottom article-jumplinks-anchor-region" id="article-jumplinks-anchor-region">
 				    <div class="inside"><?php print $content['side_bottom']; ?></div>
 				  </div>
 			  <?php endif; ?>


### PR DESCRIPTION
Adjusted logic so the jump menu block is only populated when there is main text content.

Switched some jump-menu-related css id selectors out for class selectors, and introduced the corresponding classes into the markup.

Added css selector to hide jump menu block completely (no "placeholder text" box), if no javascript (will need Modernizr for better legacy support: noted in a todo).
