### PR TITLE
Stop tables collapsing when on F&D tab or table fragment page

### DIFF
--- a/src/elife_profile/modules/custom/elife_templates/js/elife_article_tables.js
+++ b/src/elife_profile/modules/custom/elife_templates/js/elife_article_tables.js
@@ -4,7 +4,14 @@
 (function ($) {
   Drupal.behaviors.eLifeArticleTables = {
     attach: function(context, settings) {
-      if ($('.table-expansion').length > 1) {
+      var $tables = $('.table-expansion');
+      var $tablesToCollapse = $();
+      $tables.each(function () {
+        if (!$(this).parents('.fragment-type--table-wrap').length) {
+          $tablesToCollapse = $tablesToCollapse.add(this);
+        }
+      });
+      if ($tablesToCollapse.length) {
         var setupTableColorbox = function () {
           var $fragment_tables = $('a[rel="gallery-fragment-tables"]', context);
           $fragment_tables.once(function () {
@@ -22,8 +29,8 @@
         });
         $('a.table-expand-inline', context).once('eLifeArticleTablesMarkup', function() {
           $(this, context).each(function() {
-            var $inlineToggler = $(this),
-              $table = $('table, .table-foot', $inlineToggler.closest('.table-expansion'));
+            var $inlineToggler = $(this);
+            var $table = $('table, .table-foot', $inlineToggler.closest('.table-expansion'));
 
             $table.hide();
             
@@ -40,7 +47,6 @@
             });
           });
         });
-
         setupTableColorbox();
       }
     }

--- a/src/elife_profile/modules/custom/elife_templates/plugins/content_types/elife_article_fig_data.inc
+++ b/src/elife_profile/modules/custom/elife_templates/plugins/content_types/elife_article_fig_data.inc
@@ -69,7 +69,7 @@ function elife_article_fig_data_render($subtype, $conf, $args, $context) {
         'class' => 'fig-data-list clearfix',
         'id' => 'fragments-' . $type,
       ];
-      $output .= '<div id="fig-data-' . $type . '" class="group frag-' . $type . '">';
+      $output .= '<div id="fig-data-' . $type . '" class="group frag-' . $type . ' fragment-type--' . $type . '">';
       $output .= _elife_article_fig_data_title($type);
       $output .= theme('item_list', $item_list);
       $output .= '</div>';

--- a/src/elife_profile/modules/custom/elife_templates/plugins/content_types/elife_article_markup_doi.inc
+++ b/src/elife_profile/modules/custom/elife_templates/plugins/content_types/elife_article_markup_doi.inc
@@ -1,5 +1,7 @@
 <?php
 
+use eLife\EIF\ArticleVersion\Fragment;
+
 $plugin = array(
   'title' => t('Article Markup for DOI'),
   'single' => TRUE,
@@ -19,21 +21,31 @@ function elife_article_markup_doi_render($subtype, $conf, $args, $context) {
   /* @var EntityDrupalWrapper $ewrapper */
   if ($ewrapper = entity_metadata_wrapper('node', $node)) {
     if (in_array($ewrapper->getBundle(), ['elife_article_ver', 'elife_fragment'])) {
+      if ($ewrapper->field_elife_a_parent->raw()) {
+        $article_version = elife_article_version_to_dto($ewrapper->field_elife_a_parent->value());
+        $fragment = $article_version->getFragment($ewrapper->field_elife_a_doi->value());
+        if ($fragment instanceof Fragment) {
+          $fragment_type = $fragment->getType();
+        }
+        else {
+          $fragment_type = 'sub-article';
+        }
 
-      $doi = $ewrapper->field_elife_a_doi->value();
-      $article_version_id = $ewrapper->field_elife_a_parent->field_elife_a_article_version_id->value();
+        $doi = $ewrapper->field_elife_a_doi->value();
+        $article_version_id = $ewrapper->field_elife_a_parent->field_elife_a_article_version_id->value();
 
-      $markup = elife_article_markup_service();
-      $markup->addDoiQuery($article_version_id, $doi);
-      $markup = _elife_article_markup_query($markup, TRUE, TRUE);
-      $html = $markup->output();
+        $markup = elife_article_markup_service();
+        $markup->addDoiQuery($article_version_id, $doi);
+        $markup = _elife_article_markup_query($markup, TRUE, TRUE);
+        $html = $markup->output();
 
-      if ($html) {
-        elife_templates_article_page_markup_assets();
-        $block = new stdClass();
-        $block->content = $html;
+        if ($html) {
+          elife_templates_article_page_markup_assets();
+          $block = new stdClass();
+          $block->content = '<div class="fragment-type--' . $fragment_type . '">' . $html . '</div>';
 
-        return $block;
+          return $block;
+        }
       }
     }
   }


### PR DESCRIPTION
It's a bit brittle at the moment as it treats all tables on the page as collapsible if it finds one that is. Will probably need addressing, but happy for that to be done later as the need arises.
