### PR TITLE
Style figure captions

### DIFF
--- a/src/elife_profile/themes/custom/elife/css/elife-colorbox.css
+++ b/src/elife_profile/themes/custom/elife/css/elife-colorbox.css
@@ -94,6 +94,8 @@
     div#colorbox #cboxTitle {
     	background: rgba(255, 255, 255, 0.97);
     	border-top: 1px solid #dfdddd;
+			box-sizing: content-box;
+			bottom: 0;
     	color: #575759;
     	text-align: left;
     	max-height: 20px;
@@ -135,19 +137,19 @@
     	width: 100%;
     }
     	/* links to view caption, open in new window, download */	
-    	#cboxCurrent .highwire-cboxfigure-link {
+    	#cboxCurrent .elife-cboxfigure-link {
     		display: inline-block;
     		float: left;
     		font-family: Helvetica, Arial, Verdana, sans-serif;
     		font-size: 0.75em; /* 14*1.14*0.75 = 12px */
     		padding-right: 5px;
     	}
-    	#cboxCurrent .highwire-cboxfigure-link span {
+    	#cboxCurrent .elife-cboxfigure-link span {
     		display: inline-block;
     		padding-left: 4px
     	}
     	
-    	#cboxCurrent .highwire-cboxfigure-link:first-child {
+    	#cboxCurrent .elife-cboxfigure-link:first-child {
 				margin-left: -20px;
     	}
     

--- a/src/elife_profile/themes/custom/elife/css/elife-text.css
+++ b/src/elife_profile/themes/custom/elife/css/elife-text.css
@@ -335,9 +335,9 @@ h2.snippet-title {
 	font-weight: bold;
 }
 
-div.highwire-markup .fig-caption p, 
+.fig-caption p, 
 div.highwire-markup .table-caption p, 
-div.highwire-markup .fig-caption span, 
+.fig-caption span, 
 div.highwire-markup .table-caption span {
 	font-size: inherit;
 	font-weight: lighter;
@@ -352,9 +352,9 @@ div.highwire-markup .supplementary-material-expansion > p,
 div.highwire-markup .supplementary-material-expansion > span,
 div.highwire-markup .media-caption > p,
 div.highwire-markup .media-caption > span,
-div.highwire-markup .fig-caption > q,
-div.highwire-markup .fig-caption > p, 
-div.highwire-markup .fig-caption > span, 
+.fig-caption > q,
+.fig-caption > p, 
+.fig-caption > span, 
 div.highwire-markup .table-caption > p,
 div.highwire-markup .table-caption > span,
 div.highwire-markup .table-expansion table,
@@ -371,7 +371,7 @@ div.highwire-markup .table-foot .table-footnotes li > p {
 }
 
 .fig-inline-img-set .fig-caption .elife-figure-links,
-div.highwire-markup .fig-caption > .attrib {
+.fig-caption > .attrib {
 	color: #929497;
 	font-size: 0.79em;
 }
@@ -383,23 +383,23 @@ div.highwire-markup .fig-caption > .attrib {
 
 div.highwire-markup .supplementary-material .caption-title,
 div.highwire-markup .supplementary-material-expansion .caption-title,
-div.highwire-markup .media-caption .caption-title,
-div.highwire-markup .fig-caption .caption-title {
+.media-caption .caption-title,
+.fig-caption .caption-title {
 	font-weight: bold;
 	margin-bottom: 5px;
 }
 
-div.highwire-markup .supplementary-material .supplementary-material-label,
+.supplementary-material .supplementary-material-label,
 div.highwire-markup .supplementary-material-expansion .supplementary-material-label,
 div.highwire-markup .media-caption .media-label,
-div.highwire-markup .fig-caption span.fig-label, 
+.fig-caption span.fig-label, 
 div.highwire-markup .table-caption span.table-label {
 	font-family: 'Avenir LT W01 85 Heavy', sans-serif;
 	font-size: 1.15em; /* ~16px */	
 	line-height: 1.88em; /* ~30px */
 }
 
-div.highwire-markup .fig-caption p .supplementary-material .supplementary-material-label {
+.fig-caption p .supplementary-material .supplementary-material-label {
 	font-size: 1.33em;
 	line-height: 1.88em;
 }
@@ -702,8 +702,8 @@ h2 em,
 h2 .nlm-italic,
 .author-tooltip .author-tooltip-name em, 
 .author-tooltip .author-tooltip-name .nlm-italic,
-div.highwire-markup .fig-caption span.fig-label em, 
-div.highwire-markup .fig-caption span.fig-label .nlm-italic, 
+.fig-caption span.fig-label em, 
+.fig-caption span.fig-label .nlm-italic, 
 div.highwire-markup .table-caption span.table-label em, 
 div.highwire-markup .table-caption span.table-label .nlm-italic,
 .elife-article-editors h3 em, 

--- a/src/elife_profile/themes/custom/elife/css/global.css
+++ b/src/elife_profile/themes/custom/elife/css/global.css
@@ -1714,7 +1714,7 @@ p {
     }
 
 /* Figures, Tables, Video, Supplementary Data in markup */
-div.highwire-markup .fig-caption,
+.fig-caption,
 div.highwire-markup .table-caption,
 div.highwire-markup .table-caption .table-caption,
 #colorbox .table-expansion .table-caption,
@@ -1727,7 +1727,7 @@ div.highwire-markup .table-caption .table-caption,
 
 /* Supplementary Data */
 div.highwire-markup .supplementary-material > p,
-div.highwire-markup .fig-caption .supplementary-material .caption-title {
+.fig-caption .supplementary-material .caption-title {
   margin-bottom: 0;
 }
 
@@ -1735,19 +1735,19 @@ div.highwire-markup .fig-caption .supplementary-material .caption-title {
 .highwire-markup .media-caption .caption-title,
 .fig-inline-img-set .fig-caption .fig-label,
 .fig-inline-img-set .fig-caption .caption-title,
-div.highwire-markup .fig-caption p > .supplementary-material,
+.fig-caption p > .supplementary-material,
 div.highwire-markup .supplementary-material-expansion .supplementary-material-label,
 div.highwire-markup .supplementary-material-expansion .caption-title,
 div.highwire-markup span.inline-linked-media-wrapper {
   display: block;
 }
 
-div.highwire-markup .fig-caption p > .supplementary-material {
+.fig-caption p > .supplementary-material {
   margin-bottom: -10px;
 }
 
 div.highwire-markup .supplementary-material-expansion p + .inline-linked-media-wrapper,
-div.highwire-markup .fig-caption p + .inline-linked-media-wrapper {
+.fig-caption p + .inline-linked-media-wrapper {
   margin-top: -10px;
 }
 


### PR DESCRIPTION
This update vastly improves the figure caption styles. There are still some styling issues around the line underneath the captions beneath a figure carousel, and the supplementary content text associated with a figure set. This will be addressed in a later pull request.
