### PR TITLE
Hide reference tools display on article page when no js

### DIFF
--- a/src/elife_profile/modules/custom/elife_templates/js/elife_article_citation.js
+++ b/src/elife_profile/modules/custom/elife_templates/js/elife_article_citation.js
@@ -1,5 +1,6 @@
 jQuery(document).ready(function($) {
   var url = Drupal.settings.elife_article_toolbox.url;
+  $('.panel-separator--reference-tools, .reference-tools', '.sidebar-wrapper').removeClass('hidden');
   $('.st_reddit').after('<span class="st-mendeley"><a class="stButton" target="_blank" href="http://www.mendeley.com/import/?' + url + '"><span class="chicklets mendeley">Mendeley</span></a></span>');
   
   $('.api_button').click(function(){

--- a/src/elife_profile/modules/custom/elife_templates/plugins/content_types/elife_article_toolbox.inc
+++ b/src/elife_profile/modules/custom/elife_templates/plugins/content_types/elife_article_toolbox.inc
@@ -113,7 +113,8 @@ function theme_elife_article_toolbox($variables) {
   $output .= "<script type='text/javascript'>stLight.options({onhover:false , doNotHash: true, doNotCopy: true, hashAddressBar: false});</script>";
   $output .= '</div>';
 
-  $output .= '<div class="panel-separator"></div>';
+  $output .= '<div class="panel-separator panel-separator--reference-tools hidden"></div>';
+  $output .= '<div class="reference-tools hidden">';
   $output .= '<h2 class="pane-title">' . t('Reference tools:') . '</h2>';
 
   // @todo - elife - nlisgo - these are just placeholder links.
@@ -245,6 +246,7 @@ function theme_elife_article_toolbox($variables) {
     ],
   ]);
 
+  $output .= "</div> <!-- /.reference-tools -->";
   return $output;
 }
 

--- a/src/elife_profile/themes/custom/elife/css/global.css
+++ b/src/elife_profile/themes/custom/elife/css/global.css
@@ -3743,6 +3743,11 @@ a.back-to-top:hover {
 .visible-small {
   display:block;
 }
+
+.hidden {
+  display: none;
+}
+
 .hidden-small,
 ul.links.hidden-small {
   display:none;


### PR DESCRIPTION
This is a quick fix to stop the reference tool popups from being displayed when js is not available on the page.

Ideally this should be rewritten so that the links are available by default, and only rolled up into a popup when js is available to mediate the show/hide interaction; however, the absence of this improvement is not a launch blocker.
