### PR TITLE
Don't collapse table if .table-caption descendant element is missing

### DIFF
--- a/src/elife_profile/modules/custom/elife_templates/js/elife_article_tables.js
+++ b/src/elife_profile/modules/custom/elife_templates/js/elife_article_tables.js
@@ -7,7 +7,8 @@
       var $tables = $('.table-expansion');
       var $tablesToCollapse = $();
       $tables.each(function () {
-        if (!$(this).parents('.fragment-type--table-wrap').length) {
+        if (!$(this).parents('.fragment-type--table-wrap').length &&
+            !!$(this).find('.table-caption').length) {
           $tablesToCollapse = $tablesToCollapse.add(this);
         }
       });


### PR DESCRIPTION
This update addresses the issue where the reagent tables in `content/4/e07301v1` must display inline, and not have any collapse control or popup view. It is achieved by using the presence or absence of a `.table-caption` descendant element as the decider: where there is no `.table-caption`, the table displays inline.

As this is a change to how tables are handled globally, it may be that this logic exposes other tables that should be collapsed by default. In this event, the display criteria can be further refined to incorporate those cases.
