### PR TITLE
Only cache Composer packages on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ services:
 cache:
   apt: true
   directories:
-    - $HOME/.composer/cache
+    - $HOME/.composer/cache/files
     - $HOME/.drush/cache
     - $HOME/.npm
     - $HOME/custom


### PR DESCRIPTION
Currently Travis repopulates its cache each time as Composer fetches data from repositories even when just doing `composer install`. (This _might_ be caused by the Composer Merge Plugin, but I haven't checked.) Either way, we only really want to cache the actually packages themselves (so Travis will only update its cache when we've changed the version of a package).
