### PR TITLE
Fix Podcast Chapter inline entity form

### DIFF
--- a/src/elife_profile/modules/custom/elife_podcast/elife_podcast.module
+++ b/src/elife_profile/modules/custom/elife_podcast/elife_podcast.module
@@ -83,14 +83,16 @@ function elife_podcast_inline_entity_form_entity_form_alter(&$entity_form, &$for
  * Implements hook_inline_entity_form_table_fields_alter().
  */
 function elife_podcast_inline_entity_form_table_fields_alter(&$fields, $context) {
-  $fields = [
-    'chapter' => [
-      'type' => 'callback',
-      'label' => 'Chapter',
-      'sanitized' => TRUE,
-      'render_callback' => 'elife_podcast_inline_entity_form_podcast_chapter',
-    ],
-  ];
+  if ('field_elife_p_chapters' === $context['field_name']) {
+    $fields = [
+      'chapter' => [
+        'type' => 'callback',
+        'label' => 'Chapter',
+        'sanitized' => TRUE,
+        'render_callback' => 'elife_podcast_inline_entity_form_podcast_chapter',
+      ],
+    ];
+  }
 }
 
 /**


### PR DESCRIPTION
Currently the custom render callback is applied to all Inline Entity Forms, but it's meant for only one field (so is breaking person profiles as they contain taxonomy terms, not nodes).
