### PR TITLE
Remove user_admin_role

### DIFF
--- a/src/elife_profile/modules/custom/elife_users/elife_users.strongarm.inc
+++ b/src/elife_profile/modules/custom/elife_users/elife_users.strongarm.inc
@@ -35,7 +35,7 @@ function elife_users_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'user_admin_role';
-  $strongarm->value = '3';
+  $strongarm->value = '0';
   $export['user_admin_role'] = $strongarm;
 
   $strongarm = new stdClass();


### PR DESCRIPTION
This removes the `user_admin_role`. This is a bit dangerous since it refers to a role ID, but there's no guarantee roles will be added in the right order (unless we're careful). However, #274 sets up an administrator role that doesn't have access to everything, so we should just disable it.
