### PR TITLE
Keep uploaded files out of web to stop them being overwritten

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /bin/
 /cache/
 /local.settings.php
+/platform/files/
 /private/
 /src/elife_profile/libraries/
 /src/elife_profile/modules/contrib/

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -29,7 +29,7 @@ web:
 disk: 2048
 
 mounts:
-    "/web/sites/default/files": "shared:files/files"
+    "/platform/files": "shared:files/files"
     "/private": "shared:files/private"
 
 hooks:
@@ -40,6 +40,7 @@ hooks:
         drush cache-clear drush
         ./setup.sh
         cp platform/local.settings.php .
+        ln -s "../../../platform/files" "web/sites/default/files"
     deploy: |
         set -e
         ./update.sh


### PR DESCRIPTION
From my conversation with Platform.sh (ticket 6081):

> I've remembered why the symlinks for uploaded files existed: I originally assumed that they would appear before the deploy step, but they appear to be there before the build step, so when we're downloading Drupal it wipes them out. I guess this a limitation of using Drush manually. So, I've updated our config so that the files (but not private) directory is as before (ie as platform/files and symlinked).
