### PR TITLE
Style funding section of info tab

### DIFF
--- a/src/elife_profile/themes/custom/elife/css/elife-text.css
+++ b/src/elife_profile/themes/custom/elife/css/elife-text.css
@@ -1,31 +1,31 @@
-/* 
+/*
 	@file
 	Text styles for the eLife theme
-	
+
 */
 
 /* fonts from webfonts.fonts.com
-	
+
 	font-family: 'Avenir LT W01 35 Light';
 	font-family: 'AvenirLTW01-35LightObli';
-	
+
 	font-family: 'Avenir LT W01 45 Book';
 	font-family: 'AvenirLTW01-45BookObliq';
-	
+
 	font-family: 'Avenir LT W01 55 Roman';
 	font-family: 'AvenirLTW01-55Oblique';
-	
+
 	font-family: 'Avenir LT W01 65 Medium';
 	font-family: 'AvenirLTW01-65MediumObl';
-	
+
 	font-family: 'Avenir LT W01 85 Heavy';
 	font-family: 'AvenirLTW01-85HeavyObli';
-	
+
 	font-family: 'Avenir LT W01 95 Black';
 	font-family: 'AvenirLTW01-95BlackObli';
-	
+
 	Base font size: 14px
-	
+
 */
 
 /* Global */
@@ -56,13 +56,13 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 #breadcrumb bold, #breadcrumb strong,
-h1 bold, h1 strong, 
-h2 bold, h2 strong, 
-h3 bold, h3 strong, 
-h4 bold, h4 strong, 
-h5 bold, h5 strong, 
+h1 bold, h1 strong,
+h2 bold, h2 strong,
+h3 bold, h3 strong,
+h4 bold, h4 strong,
+h5 bold, h5 strong,
 h6 bold, h6 strong {
-	font-family: 'Avenir LT W01 65 Medium', Helvetica, Arial, Verdana, sans-serif; 
+	font-family: 'Avenir LT W01 65 Medium', Helvetica, Arial, Verdana, sans-serif;
 	font-weight: bold;
 }
 
@@ -125,7 +125,7 @@ h2, h4, h5, h6 {
 	line-height: 1.3em;
 }
 
-.article-text-size, 
+.article-text-size,
 .citation-links,
 ul.panels-ajax-tab {
 	font-family: 'Avenir LT W01 35 Light', Helvetica, Arial, Verdana, sans-serif;
@@ -213,9 +213,9 @@ h2.snippet-title {
 }
 
 .elife-home-featured-active .elife-home-featured-active-impact {
-	font-size: 0.86em; 
+	font-size: 0.86em;
 	line-height: 1.5em;
-	margin-bottom: 15px; 
+	margin-bottom: 15px;
 }
 
 .elife-home-featured-active .elife-home-featured-active-link {
@@ -294,7 +294,7 @@ h2.snippet-title {
 }
 	/* reset smaller font size coming from highwire.style.highwire.css */
 	div.ui-cluetip .highwire-markup { font-size: 1em; }
-  
+
 .author-detail-name,
 .author-tooltip .author-tooltip-name {
 	font-family: 'Avenir LT W01 85 Heavy', sans-serif;
@@ -335,9 +335,9 @@ h2.snippet-title {
 	font-weight: bold;
 }
 
-.fig-caption p, 
-div.highwire-markup .table-caption p, 
-.fig-caption span, 
+.fig-caption p,
+div.highwire-markup .table-caption p,
+.fig-caption span,
 div.highwire-markup .table-caption span {
 	font-size: inherit;
 	font-weight: lighter;
@@ -353,8 +353,8 @@ span.disp-formula .disp-formula-label,
 div.highwire-markup .media-caption > p,
 div.highwire-markup .media-caption > span,
 .fig-caption > q,
-.fig-caption > p, 
-.fig-caption > span, 
+.fig-caption > p,
+.fig-caption > span,
 div.highwire-markup .table-caption > p,
 div.highwire-markup .table-caption > span,
 div.highwire-markup .table-expansion table,
@@ -392,10 +392,10 @@ div.highwire-markup .supplementary-material-expansion .caption-title,
 .supplementary-material .supplementary-material-label,
 .supplementary-material-expansion label,
 div.highwire-markup .media-caption .media-label,
-.fig-caption span.fig-label, 
+.fig-caption span.fig-label,
 div.highwire-markup .table-caption span.table-label {
 	font-family: 'Avenir LT W01 85 Heavy', sans-serif;
-	font-size: 1.15em; /* ~16px */	
+	font-size: 1.15em; /* ~16px */
 	line-height: 1.88em; /* ~30px */
 }
 
@@ -415,7 +415,7 @@ div.highwire-markup .table-caption span.table-label {
 	counter-reset: reference-counter;
 	padding-left: 0;
 	list-style: none;
-} 
+}
 
 /* We only want this in the main ref list, not in the popouts. */
 .references .elife-reflinks-reflink:before {
@@ -424,13 +424,13 @@ div.highwire-markup .table-caption span.table-label {
 	float: left;
 }
 
-/* js adds 'no-counter' to replace the css counter with explicit original 
+/* js adds 'no-counter' to replace the css counter with explicit original
  *	ordinal in html so the original ordinal can be preserved when js-mediated
  * reference sorting occurs.
  */
 .references .elife-reflinks-reflink.no-counter:before {
 	display: none;
-} 
+}
 
 /* Figures & Data tab */
 #fig-data .view-options span {
@@ -441,7 +441,7 @@ div.highwire-markup .table-caption span.table-label {
 
 #fig-data .group .elife-fig-data-title-jump-link {
 	font-family: 'Avenir LT W01 35 Light', Helvetica, Arial, Verdana, sans-serif;
-	font-size: 1.15em; /* ~16px */	
+	font-size: 1.15em; /* ~16px */
 	line-height: 1.25em; /* 20px */
 	vertical-align: bottom;
 }
@@ -456,7 +456,7 @@ div.highwire-markup .table-caption span.table-label {
 	font-size: 0.86em; /* 12px */
 	line-height: 1.5em; /* 18px */
 }
-	
+
 #fig-data .related-object .name,
 #fig-data .related-object .name + .x,
 #fig-data .related-object .collab,
@@ -478,11 +478,11 @@ div.highwire-markup .table-caption span.table-label {
 
 #fig-data .related-object span.source {
 	font-size: 1.33em /* Equivalent to 16px */;
-	line-height: 1.13em;	
+	line-height: 1.13em;
 }
 
 /* Editorial Decisions & Author Response headers */
-.elife-article-editors h3, 
+.elife-article-editors h3,
 .elife-article-decision-letter h3 {
 	font-family: 'Avenir LT W01 85 Heavy', sans-serif;
 	font-size: 1.29em; /* ~18px */
@@ -505,11 +505,11 @@ div.highwire-markup .table-caption span.table-label {
 .elfie-article-metrics .elife-article-metrics-table,
 .elfie-article-metrics .elife-article-metrics-table {
 	font-size: 0.71em; /* ~10px */
-	line-height: 1.5em; 
+	line-height: 1.5em;
 }
 
-.elfie-article-metrics .elife-article-metrics-table th { 
-	font-weight: bold; 
+.elfie-article-metrics .elife-article-metrics-table th {
+	font-weight: bold;
 	letter-spacing: 0.01em;
 }
 
@@ -593,7 +593,7 @@ div.highwire-markup .table-caption span.table-label {
 /* Search list filters */
 .elife-searchlist-filter .form-item {
 	font-size: 0.86em; /* ~12px */
-	line-height: 1.5em; 
+	line-height: 1.5em;
 }
 
 
@@ -627,8 +627,8 @@ div.highwire-markup .table-caption span.table-label {
 	line-height: 1.33em;
 }
 
-.elife-article-citation .elife-citation-elife-large .highwire-cite-categories-date { 
-	line-height: 1.5em; 
+.elife-article-citation .elife-citation-elife-large .highwire-cite-categories-date {
+	line-height: 1.5em;
 }
 
 .elife-article-citation .highwire-cite-doi,
@@ -640,7 +640,7 @@ div.highwire-markup .table-caption span.table-label {
 /* Small style citations */
 .elife-article-citation .elife-citation-elife-small .elife-cite-title {
 	font-size: 1em;
-	line-height: 1.29em; 
+	line-height: 1.29em;
 }
 
 .elife-article-citation .elife-citation-elife-small .elife-cite-authors {
@@ -700,43 +700,43 @@ ul.panels-ajax-tab .nlm-italic,
 }
 
 /* Heavy weight */
-h1 em, 
-h1 .nlm-italic, 
-h2 em, 
+h1 em,
+h1 .nlm-italic,
+h2 em,
 h2 .nlm-italic,
-.author-tooltip .author-tooltip-name em, 
+.author-tooltip .author-tooltip-name em,
 .author-tooltip .author-tooltip-name .nlm-italic,
-.fig-caption span.fig-label em, 
-.fig-caption span.fig-label .nlm-italic, 
-div.highwire-markup .table-caption span.table-label em, 
+.fig-caption span.fig-label em,
+.fig-caption span.fig-label .nlm-italic,
+div.highwire-markup .table-caption span.table-label em,
 div.highwire-markup .table-caption span.table-label .nlm-italic,
-.elife-article-editors h3 em, 
-.elife-article-editors h3 .nlm-italic, 
-.elife-article-decision-letter h3 em, 
+.elife-article-editors h3 em,
+.elife-article-editors h3 .nlm-italic,
+.elife-article-decision-letter h3 em,
 .elife-article-decision-letter h3 .nlm-italic,
-.element-fig-data .element-fig-title em, 
-.element-fig-data .element-fig-title .nlm-italic, 
+.element-fig-data .element-fig-title em,
+.element-fig-data .element-fig-title .nlm-italic,
 .elife-reflinks-sortby .elife-reflinks-sortby-label em,
 .elife-reflinks-sortby .elife-reflinks-sortby-label .nlm-italic,
 .elife-searchlist-sortby .elife-searchlist-label em,
 .elife-searchlist-sortby .elife-searchlist-label .nlm-italic,
-.elife-reflink-main .elife-reflink-title em, 
+.elife-reflink-main .elife-reflink-title em,
 .elife-reflink-main .elife-reflink-title .nlm-italic,
-.elife-article-citation .elife-cite-title em, 
+.elife-article-citation .elife-cite-title em,
 .elife-article-citation .elife-cite-title .nlm-italic {
 	font-family: 'AvenirLTW01-85HeavyObli', sans-serif;
 	font-style: normal;
 }
 
 /* Form elements */
-button, input[type="reset"], 
+button, input[type="reset"],
 input[type="submit"], input[type="button"],
-textarea, select, 
-input[type="date"], input[type="datetime"], 
-input[type="datetime-local"], input[type="email"], 
-input[type="month"], input[type="number"], 
-input[type="password"], input[type="search"], 
-input[type="tel"], input[type="text"], 
+textarea, select,
+input[type="date"], input[type="datetime"],
+input[type="datetime-local"], input[type="email"],
+input[type="month"], input[type="number"],
+input[type="password"], input[type="search"],
+input[type="tel"], input[type="text"],
 input[type="time"], input[type="url"], input[type="week"] {
 	font-family: 'Avenir LT W01 35 Light', Helvetica, Arial, Verdana, sans-serif;
 }
@@ -746,18 +746,18 @@ label, label.option {
 }
 
 
-button, 
-input[type="reset"], 
-input[type="submit"], 
+button,
+input[type="reset"],
+input[type="submit"],
 input[type="button"],
 .form-item label {
 	font-family: 'Avenir LT W01 85 Heavy', sans-serif;
 	font-weight: lighter;
 }
 
-button, 
-input[type="reset"], 
-input[type="submit"], 
+button,
+input[type="reset"],
+input[type="submit"],
 input[type="button"] {
 	font-size: 0.86em;
 	line-height: 1.33em;
@@ -774,7 +774,48 @@ label.option,
 	font-style: normal;
 }
 
-input:-moz-placeholder {  
+input:-moz-placeholder {
 	font-family: 'AvenirLTW01-35LightObli', Helvetica, Arial, Verdana, sans-serif;
 	font-style: normal;
+}
+
+/* Funding section on info tab. */
+.funding-group {
+	list-style: none;
+	font-family: Helvetica, Arial, Verdana, sans-serif;
+	font-size: 0.75rem;
+	padding-left: 0;
+}
+
+.funding-group .award-id {
+	font-family: Helvetica, Arial, Verdana, sans-serif;
+	font-size: 0.75rem;
+}
+
+.funding-group .funding-source {
+	color: rgb(0, 0, 15);
+	font-family: Helvetica, Arial, Verdana, sans-serif;
+	font-size: 0.75rem;
+	font-weight: bold;
+	margin-bottom: 0;
+}
+
+.funding-group .principal-award-recipient {
+	line-height: 1.2;
+	list-style: none;
+	margin-bottom: 1rem;
+	padding-left: 0.5rem;
+	padding-top: 0;
+}
+
+.funding-group .principal-award-recipient .name:before {
+	color: #ccc;
+	content: '\2022';
+	display: inline-block;
+	width: 1em;
+}
+
+.funding-statement {
+	font-size: 0.75rem;
+	line-height: 1.2;
 }


### PR DESCRIPTION
This update styles the funding section of the info tab.

The apparent redundancy in the CSS selectors is required to override styles from elsewhere.

Note: my PHPStorm whitespace handling has changed due to upgrading the application. Only noticed it inspecting the diff on this pull request: it's stripped out trailing spaces but this has made the diff very noisy. The significant change is the new code at the end of the file.
