### PR TITLE
Don't access external URIs

### DIFF
--- a/tests/behat/features/bootstrap/ContentAlertsContext.php
+++ b/tests/behat/features/bootstrap/ContentAlertsContext.php
@@ -16,6 +16,7 @@ class ContentAlertsContext extends PageObjectContext {
    */
   public function shouldSeeSignUpFormWithGid($gid) {
     $this->getElement('Content Alerts Signup Form')->hasGid($gid);
+    $this->getElement('Content Alerts Signup Form')->hasAction('http://crm.elifesciences.org/crm/civicrm/profile/create?reset=1&gid=' . $gid);
   }
 
   /**
@@ -24,5 +25,16 @@ class ContentAlertsContext extends PageObjectContext {
   public function shouldSeeSignUpFormWithIdAndGid($id, $gid) {
     $this->getElement('Content Alerts Signup Form')->hasId($id);
     $this->getElement('Content Alerts Signup Form')->hasGid($gid);
+    $this->getElement('Content Alerts Signup Form')->hasAction('http://crm.elifesciences.org/crm/civicrm/profile/create?reset=1&gid=' . $gid);
+  }
+
+  /**
+   * @Then I should see a sign up form with id :id, gid :gid and button :button
+   */
+  public function iShouldSeeASignUpFormWithIdGidAndButton($id, $gid, $button) {
+    $this->getElement('Content Alerts Signup Form')->hasId($id);
+    $this->getElement('Content Alerts Signup Form')->hasGid($gid);
+    $this->getElement('Content Alerts Signup Form')->hasButton($button);
+    $this->getElement('Content Alerts Signup Form')->hasAction('http://crm.elifesciences.org/crm/civicrm/profile/create?reset=1&gid=' . $gid);
   }
 }

--- a/tests/behat/features/bootstrap/Page/Element/ContentAlertsSignupForm.php
+++ b/tests/behat/features/bootstrap/Page/Element/ContentAlertsSignupForm.php
@@ -47,4 +47,18 @@ class ContentAlertsSignupForm extends Element {
       throw new Exception('Expected value ' . $gid . ' not found');
     }
   }
+
+  public function hasButton($button) {
+    if (!parent::hasButton($button)) {
+      throw new Exception('Could not find button ' . $button);
+    }
+  }
+
+  public function hasAction($uri) {
+    $action_url = $this->getAttribute('action');
+
+    if ($action_url !== $uri) {
+      throw new Exception('Expected value ' . $uri . ' but found ' . $action_url);
+    }
+  }
 }

--- a/tests/behat/features/content_alerts_signup.feature
+++ b/tests/behat/features/content_alerts_signup.feature
@@ -4,7 +4,6 @@ Feature: Content alerts signup
   I want to sign up for content alerts
   So I can be alerted of the latest content
 
-  @mink:goutte
   Scenario Outline: Verify that the content alert signup form is available on category pages
     Given I set variable "elife_content_alerts_sign_up_ids" to array '{"category/<category-path>": "<id>"}'
     And I set variable "elife_content_alerts_sign_up_gids" to array '{"category/<category-path>": "<gid>"}'
@@ -12,9 +11,7 @@ Feature: Content alerts signup
       | field_elife_title | field_elife_category_type |
       | <category> | <type> |
     When I go to "category/<category-path>"
-    Then I should see a sign up form with id "<id>" and gid "<gid>"
-    When I press the "<button_text>" button
-    Then I should be on "http://crm.elifesciences.org/crm/civicrm/profile/create?reset=1&gid=<gid>"
+    Then I should see a sign up form with id "<id>", gid "<gid>" and button "<button_text>"
 
     Examples:
       | category-path | category | type | button_text | gid | id |
@@ -22,9 +19,6 @@ Feature: Content alerts signup
       | immunology | Immunology | heading | SIGN UP | 18 | immunol_rev141014 |
       | tools-and-resources | Tools and resources | display-channel | SIGN UP | 18 | research_rev141014 |
 
-  @mink:goutte
   Scenario: Verify that the content alert signup form is available on the home page
     When I go to the homepage
     Then I should see a sign up form with id "homepage_rev140402" and gid "18"
-    When I press the "Sign up" button
-    Then I should be on "http://crm.elifesciences.org/crm/civicrm/profile/create?reset=1&gid=18"


### PR DESCRIPTION
We currently have some tests failing on Travis due to a change in an external system. Tests shouldn't actually access anything outside of the application, so this refactors the tests.
