### PR TITLE
Use the latest EIF schema on the dev server.

### DIFF
--- a/src/elife_profile/elife_profile.make.dev.yml
+++ b/src/elife_profile/elife_profile.make.dev.yml
@@ -14,3 +14,10 @@ projects:
       revision: 'f0b3b384e592adee3c07aefbb1a318539cdb48f8'
   module_filter:
     version: '2.0'
+
+libraries:
+  elife-eif-schema:
+    download:
+      type: 'git'
+      url: 'ssh://git@github.com/elifesciences/elife-eif-schema.git'
+      revision: 'f9caf52d5b53d011613ca18822976ec011359d71'


### PR DESCRIPTION
A simple fix that seems to bring in the latest elife-eif-schema to the dev server.

This might not need to be merged, it's just an example to get the dev server running better that I applied as a hack already.
