### PR TITLE
Cache is_file checks

### DIFF
--- a/src/drupal.make.yml
+++ b/src/drupal.make.yml
@@ -6,3 +6,4 @@ projects:
     version: 7.41
     patch:
       - 'https://www.drupal.org/files/issues/allow_double-2009584-37.patch'
+      - 'https://www.drupal.org/files/issues/add_static_cache_to-1443308-106.patch'


### PR DESCRIPTION
This applies the patch from https://www.drupal.org/node/1443308, which can give a performance boost.

(This really should have been merged, it doesn't take almost 4 years to recognise that.)
