### PR TITLE
Queue reference deletes

### DIFF
--- a/src/elife_profile/elife_profile.make.yml
+++ b/src/elife_profile/elife_profile.make.yml
@@ -168,7 +168,11 @@ projects:
     patch:
       - 'https://www.drupal.org/files/issues/status_page_exception-2648148-1.patch'
   reference_delete:
-    version: '1.3'
+    version: '1.x-dev'
+    download:
+      type: 'git'
+      url: 'http://git.drupal.org/project/reference_delete.git'
+      revision: '67b25c6ef3180166a264f025be15da48b3b15425' # Includes fix for https://www.drupal.org/node/2487277.
   rules:
     version: '2.9'
   scheduler:

--- a/src/elife_profile/modules/custom/elife_article/elife_article.module
+++ b/src/elife_profile/modules/custom/elife_article/elife_article.module
@@ -211,6 +211,19 @@ function elife_article_permission() {
 }
 
 /**
+ * Implements hook_node_delete().
+ */
+function elife_article_node_delete($node) {
+  if ('elife_article_ver' === $node->type) {
+    db_delete('field_data_field_elife_a_versions')
+      ->condition('entity_type', 'node', '=')
+      ->condition('bundle', 'elife_article', '=')
+      ->condition('field_elife_a_versions_target_id', $node->nid, '=')
+      ->execute();
+  }
+}
+
+/**
  * Implements hook_node_view_alter().
  */
 function elife_article_node_view_alter(&$build) {

--- a/src/elife_profile/modules/custom/elife_services/resources/article.inc
+++ b/src/elife_profile/modules/custom/elife_services/resources/article.inc
@@ -222,7 +222,21 @@ function _elife_services_persist_article($data) {
   $existing = ElifeArticleVersion::fromIdentifier($article_version->getArticleVersionId(), FALSE, 'elife_article_ver', 0, 'field_elife_a_article_version_id', TRUE);
 
   if (!empty($existing)) {
+    $paths = [];
+    foreach ($existing as $nid) {
+      $path = drupal_get_path_alias($source = 'node/' . $nid);
+      if ($source !== $path) {
+        $paths[] = $path;
+      }
+    }
     node_delete_multiple($existing);
+    if (!empty($paths)) {
+      $db_or = db_or();
+      foreach ($paths as $path) {
+        $db_or->condition('alias', $path . '/%', 'LIKE');
+      }
+      db_delete('url_alias')->condition($db_or)->execute(); // Removes aliases for any fragments etc.
+    }
   }
 
   $entity = elife_article_version_from_dto($article_version, _elife_services_user_uid());

--- a/tests/behat/features/article_resource_fragments.feature
+++ b/tests/behat/features/article_resource_fragments.feature
@@ -640,13 +640,13 @@ Feature: Article Resource - Fragments (API)
               "type": "abstract",
               "title": "Abstract",
               "doi": "10.7554/eLife.00013.001",
-              "path": "content/3/e00013/abstract-1"
+              "path": "content/4/e05224/abstract-1"
             },
             {
               "type": "abstract",
               "title": "eLife digest",
               "doi": "10.7554/eLife.00013.002",
-              "path": "content/3/e00013/abstract-2"
+              "path": "content/4/e05224/abstract-2"
             }
           ]
         }
@@ -670,13 +670,13 @@ Feature: Article Resource - Fragments (API)
             {
               "type": "abstract",
               "doi": "10.7554/eLife.00013.001",
-              "path": "content/3/e00013/abstract-1"
+              "path": "content/4/e05224/abstract-1"
             },
             {
               "type": "abstract",
               "title": "eLife digest",
               "doi": "10.7554/eLife.00013.002",
-              "path": "content/3/e00013/abstract-2"
+              "path": "content/4/e05224/abstract-2"
             }
           ]
         }
@@ -691,13 +691,13 @@ Feature: Article Resource - Fragments (API)
               "type": "abstract",
               "title": "Abstract",
               "doi": "10.7554/eLife.00013.001",
-              "path": "content/3/e00013/abstract-1"
+              "path": "content/4/e05224/abstract-1"
             },
             {
               "type": "abstract",
               "title": "eLife digest",
               "doi": "10.7554/eLife.00013.002",
-              "path": "content/3/e00013/abstract-2"
+              "path": "content/4/e05224/abstract-2"
             }
           ]
         }


### PR DESCRIPTION
https://www.drupal.org/node/2487277 contained an important performance update that sees references queued for deletion rather than being immediately triggered. There hasn't been a new stable release.
