### PR TITLE
Remove revisions

### DIFF
--- a/src/elife_profile/elife_profile.install
+++ b/src/elife_profile/elife_profile.install
@@ -75,3 +75,25 @@ function elife_profile_update_7106() {
 function elife_profile_update_7107() {
   module_enable(['elife_labs'], FALSE);
 }
+
+/**
+ * Enable field_sql_norevisions.
+ */
+function elife_profile_update_7108() {
+  module_enable(['field_sql_norevisions'], FALSE);
+
+  // Remove all existing revision data.
+  module_load_include('inc', 'field_sql_norevisions', 'field_sql_norevisions.admin');
+  foreach (entity_get_info() as $entity_name => $entity) {
+    if (empty($entity['fieldable'])) {
+      continue;
+    }
+
+    foreach (array_keys($entity['bundles']) as $bundle) {
+      foreach (array_keys(field_info_instances($entity_name, $bundle)) as $field) {
+        $context = [];
+        field_sql_norevisions_batch_delete_revisions($field, $entity_name, $bundle, $context);
+      }
+    }
+  }
+}

--- a/src/elife_profile/elife_profile.make.yml
+++ b/src/elife_profile/elife_profile.make.yml
@@ -66,6 +66,12 @@ projects:
     version: '1.1'
   field_group:
     version: '1.4'
+  field_sql_norevisions:
+    version: '2.x-dev' # No recent release
+    download:
+      type: 'git'
+      url: 'http://git.drupal.org/project/field_sql_norevisions.git'
+      revision: '40a5e0eb07504a2cc9efae6dcb6482b0b4f01432'
   field_validation:
     version: '2.6'
   focal_point:

--- a/src/elife_profile/modules/custom/elife_config/elife_config.info
+++ b/src/elife_profile/modules/custom/elife_config/elife_config.info
@@ -63,6 +63,7 @@ features[variable][] = elysia_cron_alert_interval
 features[variable][] = elysia_cron_default_rules
 features[variable][] = elysia_cron_stuck_time
 features[variable][] = elysia_cron_time_limit
+features[variable][] = field_sql_norevisions_entities
 features[variable][] = jquery_update_jquery_version
 features[variable][] = node_admin_theme
 features[variable][] = page_manager_node_view_disabled

--- a/src/elife_profile/modules/custom/elife_config/elife_config.module
+++ b/src/elife_profile/modules/custom/elife_config/elife_config.module
@@ -47,6 +47,9 @@ function elife_config_imagemagick_arguments_alter(&$args, $context) {
  * Implements hook_form_FORM_ID_alter() for node_form().
  */
 function elife_config_form_node_form_alter(&$form, &$form_state, $form_id) {
+  // Will be made redundant by https://www.drupal.org/node/2505235.
+  $form['revision_information']['#access'] = FALSE;
+
   if (RABBIT_HOLE_DISPLAY_CONTENT == rabbit_hole_get_action_bundle('node', $form['#bundle'])) {
     return;
   }
@@ -58,7 +61,6 @@ function elife_config_form_node_form_alter(&$form, &$form_state, $form_id) {
     'options',
     'path',
     'redirect',
-    'revision_information',
   ];
 
   foreach ($fields as $field) {

--- a/src/elife_profile/modules/custom/elife_config/elife_config.strongarm.inc
+++ b/src/elife_profile/modules/custom/elife_config/elife_config.strongarm.inc
@@ -166,6 +166,72 @@ vcard';
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
+  $strongarm->name = 'field_sql_norevisions_entities';
+  $strongarm->value = array(
+    'cer' => array(
+      'cer' => 1,
+    ),
+    'country' => array(
+      'country' => 1,
+    ),
+    'entityqueue_subqueue' => array(
+      'elife_cover' => 1,
+      'elife_cover_preview' => 1,
+      'elife_front_matter_col_1' => 1,
+      'elife_front_matter_col_2' => 1,
+      'elife_front_matter_preview_col_1' => 1,
+      'elife_front_matter_preview_col_2' => 1,
+    ),
+    'field_collection_item' => array(
+      'field_elife_a_aff_ref' => 1,
+      'field_elife_a_basic_ref' => 1,
+      'field_elife_a_fn_ref' => 1,
+      'field_elife_a_fund_ref' => 1,
+      'field_elife_a_rel_ref' => 1,
+      'field_elife_a_related_articles' => 1,
+      'field_elife_i_cv' => 1,
+    ),
+    'node' => array(
+      'webform' => 1,
+      'elife_article' => 1,
+      'elife_article_reference' => 1,
+      'elife_article_ver' => 1,
+      'elife_collection' => 1,
+      'elife_contributor' => 1,
+      'elife_cover' => 1,
+      'elife_early_careers_interview' => 1,
+      'elife_early_careers_spotlight' => 1,
+      'elife_event' => 1,
+      'elife_fragment' => 1,
+      'elife_front_matter' => 1,
+      'elife_news_article' => 1,
+      'elife_organisation' => 1,
+      'elife_person_profile' => 1,
+      'elife_podcast' => 1,
+      'elife_podcast_chapter' => 1,
+      'elife_term_reference' => 1,
+    ),
+    'taxonomy_term' => array(
+      'elife_pp_experimental_organism' => 1,
+      'elife_pp_expertise' => 1,
+      'elife_pp_research_focus' => 1,
+      'elife_categories' => 1,
+      'elife_headings' => 1,
+      'elife_keywords' => 1,
+      'elife_n_category' => 1,
+    ),
+    'user' => array(
+      'user' => 1,
+    ),
+    'rules_config' => array(
+      'rules_config' => 1,
+    ),
+  );
+  $export['field_sql_norevisions_entities'] = $strongarm;
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
   $strongarm->name = 'jquery_update_jquery_version';
   $strongarm->value = 'default';
   $export['jquery_update_jquery_version'] = $strongarm;

--- a/src/elife_profile/modules/custom/elife_users/elife_users.features.user_permission.inc
+++ b/src/elife_profile/modules/custom/elife_users/elife_users.features.user_permission.inc
@@ -1812,10 +1812,7 @@ function elife_users_user_default_permissions() {
   // Exported permission: 'revert revisions'.
   $permissions['revert revisions'] = array(
     'name' => 'revert revisions',
-    'roles' => array(
-      'eLife Administrator' => 'eLife Administrator',
-      'eLife Editor' => 'eLife Editor',
-    ),
+    'roles' => array(),
     'module' => 'node',
   );
 
@@ -2276,10 +2273,7 @@ function elife_users_user_default_permissions() {
   // Exported permission: 'view revisions'.
   $permissions['view revisions'] = array(
     'name' => 'view revisions',
-    'roles' => array(
-      'eLife Administrator' => 'eLife Administrator',
-      'eLife Editor' => 'eLife Editor',
-    ),
+    'roles' => array(),
     'module' => 'node',
   );
 


### PR DESCRIPTION
We don't use revisioning anywhere; Drupal, however, still stores the data causing a whole bunch of superfluous SQL queries. As we're already drowning in the number, we need to stop them from happening. This adds in the [Field SQL norevisions](https://www.drupal.org/project/field_sql_norevisions) module, which appears to safely prevent this for each entity/bundle. In the event that we _do_ want revisions for a content type, for example, we can easily turn it back on.
