### PR TITLE
Concurrency data fixes

### DIFF
--- a/src/settings.php
+++ b/src/settings.php
@@ -101,3 +101,6 @@ $conf['elife_article_almvis_ga_switch_date'] = '2015-11-11';
 
 // See https://www.drupal.org/node/2009584.
 $conf['preserve_css_double_underscores'] = TRUE;
+
+// Due to concurrency issues we can't currently process more than one article at a time.
+$conf['elife_services_locks'] = 1;


### PR DESCRIPTION
We have data problems causes by concurrency issues when processing articles. So, this limits it to one at a time, then tries to clean up the data.

The data issues I've seen are:
- Data left in field tables that refers to nodes that don't exist
- Duplicate `elife_article_reference` nodes
- Missing `elife_article` nodes (I can recreate them, apart from the related article details)

There might be more problems that I haven't spotted however.
