### PR TITLE
Use Predis if the PHP extension is unavailable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "The open-access eLife journal.",
     "license": "proprietary",
     "require": {
+        "predis/predis": "~1.0",
         "wikimedia/composer-merge-plugin": "~1.3@dev"
     },
     "extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "4a29d64b20d16f7c113c59efdccc7a56",
-    "content-hash": "07fb65d10f614fce0d2bb1152c64f7eb",
+    "hash": "828f360349882d23973e5c4030ab092e",
+    "content-hash": "d077829f446a6120e9dc0b007e371961",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -830,6 +830,56 @@
                 "type"
             ],
             "time": "2015-07-25 16:39:46"
+        },
+        {
+            "name": "predis/predis",
+            "version": "v1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nrk/predis.git",
+                "reference": "84060b9034d756b4d79641667d7f9efe1aeb8e04"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nrk/predis/zipball/84060b9034d756b4d79641667d7f9efe1aeb8e04",
+                "reference": "84060b9034d756b4d79641667d7f9efe1aeb8e04",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "ext-curl": "Allows access to Webdis when paired with phpiredis",
+                "ext-phpiredis": "Allows faster serialization and deserialization of the Redis protocol"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Predis\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniele Alessandri",
+                    "email": "suppakilla@gmail.com",
+                    "homepage": "http://clorophilla.net"
+                }
+            ],
+            "description": "Flexible and feature-complete PHP client library for Redis",
+            "homepage": "http://github.com/nrk/predis",
+            "keywords": [
+                "nosql",
+                "predis",
+                "redis"
+            ],
+            "time": "2015-07-30 18:34:15"
         },
         {
             "name": "psr/http-message",

--- a/src/settings.php
+++ b/src/settings.php
@@ -46,14 +46,12 @@ $conf['file_public_path'] = 'sites/default/files';
 $conf['file_private_path'] = __DIR__ . '/../private';
 $conf['file_temporary_path'] = sys_get_temp_dir();
 
-// Configure Redis (if the PHP extension is available).
-if (extension_loaded('redis')) {
-  $conf['redis_client_interface'] = 'PhpRedis';
-  $conf['lock_inc'] = 'profiles/elife_profile/modules/contrib/redis/redis.lock.inc';
-  $conf['path_inc'] = 'profiles/elife_profile/modules/contrib/redis/redis.path.inc';
-  $conf['cache_backends'][] = 'profiles/elife_profile/modules/contrib/redis/redis.autoload.inc';
-  $conf['cache_default_class'] = 'Redis_Cache';
-}
+// Configure Redis.
+$conf['redis_client_interface'] = extension_loaded('redis') ? 'PhpRedis' : 'Predis';
+$conf['lock_inc'] = 'profiles/elife_profile/modules/contrib/redis/redis.lock.inc';
+$conf['path_inc'] = 'profiles/elife_profile/modules/contrib/redis/redis.path.inc';
+$conf['cache_backends'][] = 'profiles/elife_profile/modules/contrib/redis/redis.autoload.inc';
+$conf['cache_default_class'] = 'Redis_Cache';
 
 // Include the local settings, this MUST contain:
 //


### PR DESCRIPTION
For environments where the PHP Redis extension isn't available (eg Platform.sh's PHP 7 environments), we should use the Predis client instead of falling back to the database.
