### PR TITLE
Remove project from info files

### DIFF
--- a/src/elife_profile/modules/custom/elife_about/elife_about.info
+++ b/src/elife_profile/modules/custom/elife_about/elife_about.info
@@ -3,7 +3,6 @@ description = About section of the journal site
 core = 7.x
 package = eLife
 version = 7.x-1.0
-project = elife_about
 dependencies[] = elife_person_profile
 dependencies[] = transliteration
 files[] = elife_about.module

--- a/src/elife_profile/modules/custom/elife_archive/elife_archive.info
+++ b/src/elife_profile/modules/custom/elife_archive/elife_archive.info
@@ -2,7 +2,6 @@ name = eLife: Archive
 core = 7.x
 package = eLife
 version = 7.x-1.0
-project = elife_archive
 dependencies[] = ctools
 dependencies[] = views
 dependencies[] = views_content

--- a/src/elife_profile/modules/custom/elife_article/elife_article.info
+++ b/src/elife_profile/modules/custom/elife_article/elife_article.info
@@ -2,7 +2,6 @@ name = eLife: Article
 core = 7.x
 package = eLife
 version = 7.x-1.0
-project = elife_article
 dependencies[] = ctools
 dependencies[] = date
 dependencies[] = ds

--- a/src/elife_profile/modules/custom/elife_article_pages/elife_article_pages.info
+++ b/src/elife_profile/modules/custom/elife_article_pages/elife_article_pages.info
@@ -2,7 +2,6 @@ name = eLife: Article Pages
 core = 7.x
 package = eLife
 version = 7.x-1.0
-project = elife_article_pages
 dependencies[] = ctools
 dependencies[] = elife_podcast
 dependencies[] = page_manager

--- a/src/elife_profile/modules/custom/elife_article_reference/elife_article_reference.info
+++ b/src/elife_profile/modules/custom/elife_article_reference/elife_article_reference.info
@@ -2,7 +2,6 @@ name = eLife: Article Reference
 core = 7.x
 package = eLife
 version = 7.x-1.0
-project = elife_article_reference
 dependencies[] = ctools
 dependencies[] = elife_article
 dependencies[] = entity

--- a/src/elife_profile/modules/custom/elife_article_rss/elife_article_rss.info
+++ b/src/elife_profile/modules/custom/elife_article_rss/elife_article_rss.info
@@ -2,7 +2,6 @@ name = eLife: Article RSS
 core = 7.x
 package = eLife
 version = 7.x-1.0
-project = elife_article_rss
 dependencies[] = ctools
 dependencies[] = elife_article
 dependencies[] = fe_date

--- a/src/elife_profile/modules/custom/elife_body_field/elife_body_field.info
+++ b/src/elife_profile/modules/custom/elife_body_field/elife_body_field.info
@@ -2,5 +2,4 @@ name = eLife: Body Field
 core = 7.x
 package = eLife
 version = 7.x-1.0
-project = elife_body_field
 dependencies[] = token

--- a/src/elife_profile/modules/custom/elife_collection/elife_collection.info
+++ b/src/elife_profile/modules/custom/elife_collection/elife_collection.info
@@ -2,7 +2,6 @@ name = eLife: Collection
 core = 7.x
 package = eLife
 version = 7.x-1.0
-project = elife_collection
 dependencies[] = ctools
 dependencies[] = ds
 dependencies[] = elife_article

--- a/src/elife_profile/modules/custom/elife_config/elife_config.info
+++ b/src/elife_profile/modules/custom/elife_config/elife_config.info
@@ -3,7 +3,6 @@ description = Configuration for the site
 core = 7.x
 package = eLife
 version = 7.x-1.0
-project = elife_config
 dependencies[] = caption_filter
 dependencies[] = ckeditor
 dependencies[] = ctools

--- a/src/elife_profile/modules/custom/elife_early_careers/elife_early_careers.info
+++ b/src/elife_profile/modules/custom/elife_early_careers/elife_early_careers.info
@@ -3,7 +3,6 @@ description = Early careers section of the journal site
 core = 7.x
 package = eLife
 version = 7.x-1.0
-project = elife_early_careers
 dependencies[] = ctools
 dependencies[] = ds
 dependencies[] = elife_house_style

--- a/src/elife_profile/modules/custom/elife_events/elife_events.info
+++ b/src/elife_profile/modules/custom/elife_events/elife_events.info
@@ -2,7 +2,6 @@ name = eLife: Events
 core = 7.x
 package = eLife
 version = 7.x-1.0
-project = elife_events
 dependencies[] = ctools
 dependencies[] = date
 dependencies[] = ds

--- a/src/elife_profile/modules/custom/elife_front_matter/elife_front_matter.info
+++ b/src/elife_profile/modules/custom/elife_front_matter/elife_front_matter.info
@@ -2,7 +2,6 @@ name = eLife: Front matter
 core = 7.x
 package = eLife
 version = 7.x-1.0
-project = elife_front_matter
 dependencies[] = ctools
 dependencies[] = elife_article_reference
 dependencies[] = elife_content_alerts

--- a/src/elife_profile/modules/custom/elife_house_style/elife_house_style.info
+++ b/src/elife_profile/modules/custom/elife_house_style/elife_house_style.info
@@ -2,7 +2,6 @@ name = eLife: House Style
 core = 7.x
 package = eLife
 version = 7.x-1.0
-project = elife_house_style
 dependencies[] = entity
 dependencies[] = features
 dependencies[] = filter

--- a/src/elife_profile/modules/custom/elife_http_client/elife_http_client.info
+++ b/src/elife_profile/modules/custom/elife_http_client/elife_http_client.info
@@ -2,5 +2,4 @@ name = eLife HTTP Client
 core = 7.x
 package = eLife
 version = 7.x-1.0
-project = elife_http_client
 files[] = elife_http_client.module

--- a/src/elife_profile/modules/custom/elife_labs/elife_labs.info
+++ b/src/elife_profile/modules/custom/elife_labs/elife_labs.info
@@ -2,7 +2,6 @@ name = eLife Labs
 core = 7.x
 package = eLife
 version = 7.x-1.0
-project = elife_labs
 dependencies[] = ctools
 dependencies[] = elife_house_style
 dependencies[] = features

--- a/src/elife_profile/modules/custom/elife_monolog/elife_monolog.info
+++ b/src/elife_profile/modules/custom/elife_monolog/elife_monolog.info
@@ -2,5 +2,4 @@ name = eLife: Monolog
 core = 7.x
 package = eLife
 version = 7.x-1.0
-project = elife_monolog
 project path = profiles/elife_profile/modules/custom

--- a/src/elife_profile/modules/custom/elife_organisation/elife_organisation.info
+++ b/src/elife_profile/modules/custom/elife_organisation/elife_organisation.info
@@ -2,7 +2,6 @@ name = eLife: Organisation
 core = 7.x
 package = eLife
 version = 7.x-1.0
-project = elife_organisation
 dependencies[] = countries
 dependencies[] = ctools
 dependencies[] = features

--- a/src/elife_profile/modules/custom/elife_person_profile/elife_person_profile.info
+++ b/src/elife_profile/modules/custom/elife_person_profile/elife_person_profile.info
@@ -2,7 +2,6 @@ name = eLife: Person Profile
 core = 7.x
 package = eLife
 version = 7.x-1.0
-project = elife_article
 dependencies[] = auto_entitylabel
 dependencies[] = ctools
 dependencies[] = ds

--- a/src/elife_profile/modules/custom/elife_podcast/elife_podcast.info
+++ b/src/elife_profile/modules/custom/elife_podcast/elife_podcast.info
@@ -2,7 +2,6 @@ name = eLife: Podcast
 core = 7.x
 package = eLife
 version = 7.x-1.0
-project = elife_podcast
 dependencies[] = cer
 dependencies[] = ctools
 dependencies[] = ds

--- a/src/elife_profile/modules/custom/elife_resources/elife_resources.info
+++ b/src/elife_profile/modules/custom/elife_resources/elife_resources.info
@@ -3,6 +3,5 @@ description = Access resources for articles such as PDF.
 core = 7.x
 package = eLife
 version = 7.x-1.0
-project = elife_resources
 
 files[] = elife_resources.class.inc

--- a/src/elife_profile/modules/custom/elife_search/elife_search.info
+++ b/src/elife_profile/modules/custom/elife_search/elife_search.info
@@ -2,7 +2,6 @@ name = eLife: Search
 core = 7.x
 package = eLife
 version = 7.x-1.0
-project = elife_search
 dependencies[] = elife_article
 dependencies[] = elife_config
 dependencies[] = elysia_cron

--- a/src/elife_profile/modules/custom/elife_services_config/elife_services_config.info
+++ b/src/elife_profile/modules/custom/elife_services_config/elife_services_config.info
@@ -3,7 +3,6 @@ description = Configuration for eLife Services
 core = 7.x
 package = eLife
 version = 7.x-1.0
-project = elife_services_config
 dependencies[] = ctools
 dependencies[] = elife_services
 dependencies[] = rest_server

--- a/src/elife_profile/modules/custom/elife_term_reference/elife_term_reference.info
+++ b/src/elife_profile/modules/custom/elife_term_reference/elife_term_reference.info
@@ -2,7 +2,6 @@ name = eLife: Term Reference
 core = 7.x
 package = eLife
 version = 7.x-1.0
-project = elife_term_reference
 dependencies[] = elife_article
 dependencies[] = elife_config
 dependencies[] = rabbit_hole

--- a/src/elife_profile/modules/custom/elife_users/elife_users.info
+++ b/src/elife_profile/modules/custom/elife_users/elife_users.info
@@ -2,7 +2,6 @@ name = eLife: Users
 core = 7.x
 package = eLife
 version = 7.x-1.0
-project = elife_users
 dependencies[] = admin_menu
 dependencies[] = auto_entitylabel
 dependencies[] = better_formats


### PR DESCRIPTION
We shouldn't include `project` in local `.info` files as it causes Drupal/Drush to check for updates (and fail).
