### PR TITLE
Let builds match the deployment environment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
         }
     },
     "config": {
-        "bin-dir": "bin/"
+        "bin-dir": "bin/",
+        "platform": {
+            "php": "5.6"
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "828f360349882d23973e5c4030ab092e",
-    "content-hash": "d077829f446a6120e9dc0b007e371961",
+    "hash": "cdbb7596c5e2c11a72e76a4f87d6033d",
+    "content-hash": "e404cd4156f4a7aa90934f194465a485",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -3537,5 +3537,8 @@
     "platform": {
         "php": ">=5.5"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "5.6"
+    }
 }


### PR DESCRIPTION
Platform.sh enterprise currently builds packages on an environment with only PHP 5.4, which fails as we have dependencies that requires later versions. This adds in the Composer setting that defines your deployment version, so it can be built.
