### PR TITLE
Fix podcast chapter titles

### DIFF
--- a/src/elife_profile/modules/custom/elife_podcast/elife_podcast.ds.inc
+++ b/src/elife_profile/modules/custom/elife_podcast/elife_podcast.ds.inc
@@ -37,25 +37,26 @@ function elife_podcast_ds_field_settings_info() {
       'label' => 'hidden',
       'format' => 'default',
     ),
-    'title' => array(
-      'weight' => '0',
-      'label' => 'hidden',
-      'format' => 'default',
-      'formatter_settings' => array(
-        'link' => '0',
-        'wrapper' => 'h2',
-        'class' => '',
-        'ft' => array(
-          'func' => 'theme_ds_field_reset',
-        ),
-      ),
-    ),
     'field_elife_pc_text' => array(
       'formatter_settings' => array(
         'ft' => array(
           'func' => 'theme_ds_field_expert',
           'fi' => TRUE,
           'fi-el' => 'p',
+          'fi-cl' => '',
+          'fi-at' => '',
+          'fi-def-at' => FALSE,
+          'fi-odd-even' => FALSE,
+          'fi-first-last' => FALSE,
+        ),
+      ),
+    ),
+    'field_elife_pc_title' => array(
+      'formatter_settings' => array(
+        'ft' => array(
+          'func' => 'theme_ds_field_expert',
+          'fi' => TRUE,
+          'fi-el' => 'h2',
           'fi-cl' => '',
           'fi-at' => '',
           'fi-def-at' => FALSE,
@@ -229,13 +230,13 @@ function elife_podcast_ds_layout_settings_info() {
   $ds_layout->settings = array(
     'regions' => array(
       'ds_content' => array(
-        0 => 'title',
+        0 => 'field_elife_pc_title',
         1 => 'field_elife_pc_text',
         2 => 'elife_pc_subject',
       ),
     ),
     'fields' => array(
-      'title' => 'ds_content',
+      'field_elife_pc_title' => 'ds_content',
       'field_elife_pc_text' => 'ds_content',
       'elife_pc_subject' => 'ds_content',
     ),

--- a/src/elife_profile/modules/custom/elife_podcast/elife_podcast.features.field_instance.inc
+++ b/src/elife_profile/modules/custom/elife_podcast/elife_podcast.features.field_instance.inc
@@ -786,8 +786,9 @@ function elife_podcast_field_default_field_instances() {
       ),
       'teaser' => array(
         'label' => 'hidden',
+        'module' => 'text',
         'settings' => array(),
-        'type' => 'hidden',
+        'type' => 'text_default',
         'weight' => 0,
       ),
     ),

--- a/tests/behat/features/podcast.feature
+++ b/tests/behat/features/podcast.feature
@@ -39,6 +39,7 @@ Feature: Podcast
     Then I should see "Podcast One" in the ".hero-block__title" element
     Then I should see "Podcast" in the ".hero-block__title i" element
     And I should see "Episode 1" in the ".hero-block__sub_title" element
+    And I should not see "Episode" in the ".pane-node-field-elife-p-chapters" element
     And I should see "Chapter One" in the ".pane-node-field-elife-p-chapters" element
     And I should see "One" in the ".pane-node-field-elife-p-chapters i" element
 


### PR DESCRIPTION
Currently podcast chapter titles show as 'Episode x: Title' rather than just 'Title', as the Drupal node title is used instead of the field. This fixes it.
