### PR TITLE
Fix alignment of compact podcast teasers

### DIFF
--- a/src/elife_profile/modules/custom/elife_podcast/css/podcast-teaser.css
+++ b/src/elife_profile/modules/custom/elife_podcast/css/podcast-teaser.css
@@ -45,6 +45,10 @@ div.panel-pane div.node.podcast-teaser--compact {
     padding-left: 170px;
   }
 
+  div.panel-pane div.node.podcast-teaser--compact {
+    padding-left: 35px;
+  }
+
   .podcast-teaser__image {
     margin-left: -170px;
     width: 150px;


### PR DESCRIPTION
#350 introduced a problem with the alignment of compact podcast teasers, this overrides it back. (Ugly, but not worth redoing properly (especially with Drupal's specificity problems).)
