### PR TITLE
Make cache path unique

### DIFF
--- a/platform/local.settings.php
+++ b/platform/local.settings.php
@@ -22,7 +22,7 @@ $databases = [
     ],
 ];
 
-$conf['elife_cache_dir'] = sys_get_temp_dir() . '/elife';
+$conf['elife_cache_dir'] = sprintf('%s/%s-%s-%s', sys_get_temp_dir(), 'elife', $_SERVER['PLATFORM_PROJECT'], $_SERVER['PLATFORM_ENVIRONMENT']);
 $conf['elife_environment'] = ELIFE_ENVIRONMENT_PRODUCTION;
 
 $conf['search_api_override_mode'] = 'default';


### PR DESCRIPTION
We had a problem on Platform.sh where the JMS Serializer on the production environment could write to its cache directory causing any `POST`ed articles to return a 500.

As the filesystem is write-only on Platform.sh we're caching some stuff into `/tmp/elife`. Turns out, for some reason, that the filesystem is synchronised between the production and staging platforms (you can see the other environment's log files too), so it was owned by the `elifesciences_stg` user, but the `elifesciences` user couldn't write to it. So, I've changed the path to be `/tmp/elife-{project}-{environment}`, so for production it's `/tmp/elife-elifesciences-master`, and for staging `/tmp/elife-elifesciences_stg_master`. The standard platform environments don't have the same problem, but they might as well share the same configuration, so master would be `/tmp/elife/elife-gzorsqexlzqta-master`, and a PR environment `/tmp/elife-gzorsqexlzqta-pr-388`.
