### PR TITLE
Add correct display channel css class to sidebar related item

### DIFF
--- a/src/elife_profile/modules/custom/elife_article/elife_article.module
+++ b/src/elife_profile/modules/custom/elife_article/elife_article.module
@@ -1713,12 +1713,14 @@ function _elife_article_xmltohtml($string) {
  */
 function _elife_article_display_channel_links(ArticleVersion $article_version, $options = []) {
   $items = [];
-  if (!empty($article_version->getDisplayChannels())) {
+  $display_channels = $article_version->getDisplayChannels();
+  if (!empty($display_channels)) {
     $options += [
       'html' => TRUE,
       'attributes' => [
         'class' => [
           'category-display-channel',
+          strtolower(preg_replace('/[^a-zA-Z0-9-]+/', '-', $display_channels[0])),
         ],
       ],
     ];


### PR DESCRIPTION
Would appreciate @nlisgo or @thewilkybarkid sanity checking this. It works, but is the assumption valid about the first element of `$article_version->getDisplayChannels()` always being exactly what's wanted here?

You can see the effect of the change at `/content/2/e00731v1`: the righthand sidebar's top related content item has its "Insight" Lozenge in the correct green colour.
