### PR TITLE
Add index to field

### DIFF
--- a/src/elife_profile/modules/custom/elife_article/elife_article.install
+++ b/src/elife_profile/modules/custom/elife_article/elife_article.install
@@ -172,3 +172,14 @@ function elife_article_update_7102() {
 function elife_article_update_7103() {
   variable_set('elife_article_source_assets_glencoe_api', 'http://movie-usa.glencoesoftware.com/metadata/');
 }
+
+/**
+ * Add index to improve ElifeArticleVersion::retrieveRelatedArticles()
+ * performance.
+ */
+function elife_article_update_7104() {
+  db_add_index('field_data_field_elife_a_doi', 'elife_type_value', [
+    'entity_type',
+    'field_elife_a_doi_value',
+  ]);
+}

--- a/src/elife_profile/modules/custom/elife_article/elife_article.module
+++ b/src/elife_profile/modules/custom/elife_article/elife_article.module
@@ -2534,3 +2534,15 @@ function elife_article_doi_to_glencoe_data_cache($doi) {
 
   return $doi_to_glencoe_api_cache;
 }
+
+/**
+ * Implements hook_field_create_field().
+ */
+function elife_article_field_create_field($field) {
+  if ('field_elife_a_doi' === $field['field_name']) {
+    db_add_index('field_data_field_elife_a_doi', 'elife_type_value', [
+      'entity_type',
+      'field_elife_a_doi_value',
+    ]);
+  }
+}


### PR DESCRIPTION
A query can be run like:

``` sql
SELECT fc.item_id AS fc_id, rel.entity_id AS endpoint_1, vers.entity_id AS endpoint_2, typ.field_elife_a_rel_article_type_value AS article_type, ver.field_elife_a_version_value AS article_version,  sta.field_elife_a_status_value AS article_status, aid_1.field_elife_a_article_id_value AS endpoint_1_article_id, aid_2.field_elife_a_article_id_value AS endpoint_2_article_id, node_1.nid AS endpoint_1_article_ver_nid, node_2.nid AS endpoint_2_article_ver_nid, node_1.status AS endpoint_1_article_ver_status, node_2.status AS endpoint_2_article_ver_status FROM field_collection_item fc LEFT OUTER JOIN field_data_field_elife_a_doi doi ON doi.entity_type = 'field_collection_item' AND doi.entity_id = fc.item_id LEFT OUTER JOIN field_data_field_elife_a_rel_article_ref ref ON ref.entity_type = 'field_collection_item' AND ref.entity_id = fc.item_id LEFT OUTER JOIN field_data_field_elife_a_doi doi_dest ON doi_dest.entity_type = 'node' AND doi_dest.field_elife_a_doi_value = doi.field_elife_a_doi_value LEFT OUTER JOIN field_data_field_elife_a_versions vers ON vers.field_elife_a_versions_target_id = doi_dest.entity_id LEFT OUTER JOIN field_data_field_elife_a_related_articles rel ON rel.field_elife_a_related_articles_value = fc.item_id LEFT OUTER JOIN field_data_field_elife_a_rel_article_type typ ON typ.entity_id = fc.item_id LEFT OUTER JOIN field_data_field_elife_a_version ver ON ver.entity_id = doi_dest.entity_id LEFT OUTER JOIN field_data_field_elife_a_status sta ON sta.entity_id = doi_dest.entity_id LEFT OUTER JOIN field_data_field_elife_a_article_id aid_1 ON aid_1.entity_id = rel.entity_id LEFT OUTER JOIN field_data_field_elife_a_article_id aid_2 ON aid_2.entity_id = doi_dest.entity_id LEFT OUTER JOIN field_data_field_elife_a_versions vers_1 ON vers_1.entity_id = rel.entity_id AND vers_1.delta = 0 LEFT OUTER JOIN field_data_field_elife_a_versions vers_2 ON vers_2.entity_id = vers.entity_id AND vers_2.delta = 0 LEFT OUTER JOIN node node_1 ON node_1.nid = vers_1.field_elife_a_versions_target_id LEFT OUTER JOIN node node_2 ON node_2.nid = vers_2.field_elife_a_versions_target_id WHERE  (fc.field_name = 'field_elife_a_related_articles') AND( (ref.field_elife_a_rel_article_ref_target_id != vers.entity_id) OR (ref.field_elife_a_rel_article_ref_target_id IS NULL ) ) GROUP BY endpoint_1, doi.field_elife_a_doi_value ORDER BY rel.delta ASC;
```

which can be very slow (up to 10 seconds). It appears that adding a single index takes it down to milliseconds.
