### PR TITLE
Attach CSS/JS correctly to node view modes

### DIFF
--- a/src/elife_profile/modules/custom/elife_article/elife_article.module
+++ b/src/elife_profile/modules/custom/elife_article/elife_article.module
@@ -316,6 +316,19 @@ function elife_article_node_delete($node) {
 }
 
 /**
+ * Implements hook_node_view().
+ */
+function elife_article_node_view($node, $view_mode, $langcode) {
+  if (
+    'elife_article_ver' === $node->type
+    &&
+    in_array($view_mode, ['teaser', 'elife_teaser_compact'])
+  ) {
+    $node->content['#attached']['css'][] = drupal_get_path('module', 'elife_article') . '/css/article-teaser.css';
+  }
+}
+
+/**
  * Implements hook_node_view_alter().
  */
 function elife_article_node_view_alter(&$build) {
@@ -340,7 +353,6 @@ function elife_article_preprocess_node(&$variables) {
     ])
   ) {
     $variables['date'] = format_date($variables['node']->created, 'custom', 'j F Y');
-    drupal_add_css(drupal_get_path('module', 'elife_article') . '/css/article-teaser.css');
 
     $dto = elife_article_version_to_dto($variables['node']);
 

--- a/src/elife_profile/modules/custom/elife_collection/elife_collection.module
+++ b/src/elife_profile/modules/custom/elife_collection/elife_collection.module
@@ -23,13 +23,24 @@ function elife_collection_elife_body_field() {
 }
 
 /**
+ * Implements hook_node_view().
+ */
+function elife_collection_node_view($node, $view_mode, $langcode) {
+  if (
+    'elife_collection' === $node->type
+    &&
+    in_array($view_mode, ['teaser', 'elife_teaser_compact'])
+  ) {
+    $node->content['#attached']['css'][] = drupal_get_path('module', 'elife_collection') . '/css/collection-teaser.css';
+  }
+}
+
+/**
  * Implements template_preprocess_node().
  */
 function elife_collection_preprocess_node(&$variables) {
   if ('elife_collection' === $variables['type']) {
     if (in_array($variables['view_mode'], ['teaser', 'elife_teaser_compact'])) {
-      drupal_add_css(drupal_get_path('module', 'elife_collection') . '/css/collection-teaser.css');
-
       $curators = [];
       $curators_short = [];
 

--- a/src/elife_profile/modules/custom/elife_early_careers_interviews/elife_early_careers_interviews.module
+++ b/src/elife_profile/modules/custom/elife_early_careers_interviews/elife_early_careers_interviews.module
@@ -7,13 +7,15 @@
 include_once 'elife_early_careers_interviews.features.inc';
 
 /**
- * Implements template_preprocess_node().
+ * Implements hook_node_view().
  */
-function elife_early_careers_interviews_preprocess_node(&$variables) {
-  if ('elife_early_careers_interview' === $variables['type']) {
-    if (in_array($variables['view_mode'], ['teaser', 'elife_teaser_compact'])) {
-      drupal_add_css(drupal_get_path('module', 'elife_collection') . '/css/collection-teaser.css');
-    }
+function elife_early_careers_interviews_node_view($node, $view_mode, $langcode) {
+  if (
+    'elife_early_careers_interview' === $node->type
+    &&
+    in_array($view_mode, ['teaser', 'elife_teaser_compact'])
+  ) {
+    $node->content['#attached']['css'][] = drupal_get_path('module', 'elife_collection') . '/css/collection-teaser.css';
   }
 }
 

--- a/src/elife_profile/modules/custom/elife_events/elife_events.module
+++ b/src/elife_profile/modules/custom/elife_events/elife_events.module
@@ -7,11 +7,11 @@
 include_once 'elife_events.features.inc';
 
 /**
- * Implements template_preprocess_node().
+ * Implements hook_node_view().
  */
-function elife_events_preprocess_node(&$variables) {
-  if ('elife_event' === $variables['type'] && 'teaser' === $variables['view_mode']) {
-    drupal_add_css(drupal_get_path('module', 'elife_events') . '/css/event-teaser.css');
+function elife_events_node_view($node, $view_mode, $langcode) {
+  if ('elife_event' === $node->type && 'teaser' === $view_mode) {
+    $node->content['#attached']['css'][] = drupal_get_path('module', 'elife_events') . '/css/event-teaser.css';
   }
 }
 

--- a/src/elife_profile/modules/custom/elife_news/elife_news.module
+++ b/src/elife_profile/modules/custom/elife_news/elife_news.module
@@ -7,11 +7,11 @@
 include_once 'elife_news.features.inc';
 
 /**
- * Implements template_preprocess_node().
+ * Implements hook_node_view().
  */
-function elife_news_preprocess_node(&$variables) {
-  if ('elife_news_article' === $variables['type'] && 'teaser' === $variables['view_mode']) {
-    drupal_add_css(drupal_get_path('module', 'elife_news') . '/css/news-article-teaser.css');
+function elife_news_node_view($node, $view_mode, $langcode) {
+  if ('elife_news_article' === $node->type && 'teaser' === $view_mode) {
+    $node->content['#attached']['css'][] = drupal_get_path('module', 'elife_news') . '/css/news-article-teaser.css';
   }
 }
 

--- a/src/elife_profile/modules/custom/elife_person_profile/elife_person_profile.module
+++ b/src/elife_profile/modules/custom/elife_person_profile/elife_person_profile.module
@@ -69,17 +69,20 @@ function elife_person_profile_field_group_build_pre_render_alter(&$element) {
 }
 
 /**
- * Implements template_preprocess_node().
+ * Implements hook_node_view().
  */
-function elife_person_profile_preprocess_node(&$variables) {
-  if ('elife_person_profile' === $variables['type']) {
-    if ('elife_teaser_compact' === $variables['view_mode']) {
-      drupal_add_css(drupal_get_path('module', 'elife_person_profile') . '/css/person-profile-compact.css');
+function elife_person_profile_node_view($node, $view_mode, $langcode) {
+  if ('elife_person_profile' === $node->type) {
+    if ('elife_teaser_compact' === $view_mode) {
+      $node->content['#attached']['css'][] = drupal_get_path('module', 'elife_person_profile') . '/css/person-profile-compact.css';
     }
     else {
-      drupal_add_css(drupal_get_path('module', 'elife_person_profile') . '/css/person-profile.css');
-      drupal_add_js(drupal_get_path('module', 'elife_person_profile') . '/js/person-profile.js', ['scope' => 'footer']);
-      drupal_add_js(['elifePersonProfile' => ['moduleFolder' => drupal_get_path('module', 'elife_person_profile')]], 'setting');
+      $node->content['#attached']['css'][] = drupal_get_path('module', 'elife_person_profile') . '/css/person-profile.css';
+      $node->content['#attached']['js'][drupal_get_path('module', 'elife_person_profile') . '/js/person-profile.js'] = ['scope' => 'footer'];
+      $node->content['#attached']['js'][] = [
+        'data' => ['elifePersonProfile' => ['moduleFolder' => drupal_get_path('module', 'elife_person_profile')]],
+        'type' => 'setting',
+      ];
     }
   }
 }

--- a/src/elife_profile/modules/custom/elife_podcast/elife_podcast.module
+++ b/src/elife_profile/modules/custom/elife_podcast/elife_podcast.module
@@ -121,17 +121,22 @@ function elife_podcast_elife_body_field() {
 }
 
 /**
+ * Implements hook_node_view().
+ */
+function elife_podcast_node_view($node, $view_mode, $langcode) {
+  if (
+    in_array($node->type, ['elife_podcast', 'elife_podcast_chapter'])
+    &&
+    in_array($view_mode, ['teaser', 'elife_teaser_compact'])
+  ) {
+    $node->content['#attached']['css'][] = drupal_get_path('module', 'elife_podcast') . '/css/podcast-teaser.css';
+  }
+}
+
+/**
  * Implements template_preprocess_node().
  */
 function elife_podcast_preprocess_node(&$variables) {
-  if (
-    in_array($variables['type'], ['elife_podcast', 'elife_podcast_chapter'])
-    &&
-    in_array($variables['view_mode'], ['teaser', 'elife_teaser_compact'])
-  ) {
-    drupal_add_css(drupal_get_path('module', 'elife_podcast') . '/css/podcast-teaser.css');
-  }
-
   if ('elife_podcast' === $variables['type']) {
     $variables['elife_p_actions'] = theme('item_list', [
       'items' => [


### PR DESCRIPTION
Currently trying to cache rendered node view mode results in missing CSS/JS, so this corrects the problem.
