### PR TITLE
Make sure field_sql_norevisions is enabled

### DIFF
--- a/src/elife_profile/elife_profile.info
+++ b/src/elife_profile/elife_profile.info
@@ -52,6 +52,7 @@ dependencies[] = field_collection
 dependencies[] = field_formatter_settings
 dependencies[] = field_group
 dependencies[] = field_object
+dependencies[] = field_sql_norevisions
 dependencies[] = field_validation
 dependencies[] = focal_point
 dependencies[] = globalredirect

--- a/src/elife_profile/elife_profile.install
+++ b/src/elife_profile/elife_profile.install
@@ -221,3 +221,10 @@ function elife_profile_update_7117() {
 function elife_profile_update_7118() {
   _elife_article_markup_cache_clear_all();
 }
+
+/**
+ * Make sure field_sql_norevisions is enabled.
+ */
+function elife_profile_update_7119() {
+  elife_profile_update_7108();
+}

--- a/src/elife_profile/modules/custom/elife_config/elife_config.info
+++ b/src/elife_profile/modules/custom/elife_config/elife_config.info
@@ -11,6 +11,7 @@ dependencies[] = ds_extras
 dependencies[] = elysia_cron
 dependencies[] = fe_date
 dependencies[] = features
+dependencies[] = field_sql_norevisions
 dependencies[] = filter
 dependencies[] = page_theme
 dependencies[] = pathauto

--- a/src/elife_profile/modules/custom/elife_config/elife_config.strongarm.inc
+++ b/src/elife_profile/modules/custom/elife_config/elife_config.strongarm.inc
@@ -230,6 +230,7 @@ vcard';
     ),
     'node' => array(
       'webform' => 1,
+      'elife_annual_report' => 1,
       'elife_article' => 1,
       'elife_article_reference' => 1,
       'elife_article_ver' => 1,
@@ -241,6 +242,7 @@ vcard';
       'elife_event' => 1,
       'elife_fragment' => 1,
       'elife_front_matter' => 1,
+      'elife_labs_entry' => 1,
       'elife_news_article' => 1,
       'elife_organisation' => 1,
       'elife_person_profile' => 1,


### PR DESCRIPTION
For an unknown reason `field_sql_norevisions` is currently disabled in production, which will be contributing to the performance problems we're seeing.

This should make sure that it's enabled, for realz.
