### PR TITLE
Stop HTTP and HTTPS being mixed up in caches

### DIFF
--- a/src/elife_profile/elife_profile.make.yml
+++ b/src/elife_profile/elife_profile.make.yml
@@ -41,8 +41,12 @@ projects:
     version: '3.2'
   display_cache:
     version: '1.3'
+    patch:
+      - 'https://www.drupal.org/files/issues/display_cache_base_urls-2679639-1.patch'
   disqus:
     version: '1.12'
+    patch:
+      - 'http://cgit.drupalcode.org/disqus/patch/?id=25e573dfe32ec5102148e62f896e72aae84c3fa3'
   ds:
     version: '2.11'
   efq_extra_field:

--- a/src/elife_profile/modules/custom/elife_article/elife_article.module
+++ b/src/elife_profile/modules/custom/elife_article/elife_article.module
@@ -55,7 +55,7 @@ function elife_article_module_implements_alter(&$implementations, $hook) {
   }
 
   switch ($hook) {
-    case 'node_load':
+    case 'entitycache_node_load':
       // Immediately after Disqus.
       $group = $implementations['elife_article'];
       unset($implementations['elife_article']);
@@ -545,9 +545,9 @@ function elife_article_preprocess_node(&$variables) {
 }
 
 /**
- * Implements hook_node_load().
+ * Implements hook_entitycache_node_load().
  */
-function elife_article_node_load($nodes, $types) {
+function elife_article_entitycache_node_load($nodes) {
   foreach ($nodes as $node) {
     if ('elife_article_ver' !== $node->type || empty($node->field_elife_a_article_id[LANGUAGE_NONE]) || empty($node->disqus)) {
       continue;


### PR DESCRIPTION
The Display Cache and Disqus (via Entity Cache) modules currently don't separate HTTP and HTTPS references in Redis.
