### PR TITLE
Fix typo on article and author info tab

### DIFF
--- a/src/elife_profile/modules/custom/elife_article/src/ElifeMarkupService.php
+++ b/src/elife_profile/modules/custom/elife_article/src/ElifeMarkupService.php
@@ -26,7 +26,7 @@ abstract class ElifeMarkupService implements ElifeMarkupServiceInterface {
     'author-info-equal-contrib' => 'Equal contributions',
     'author-info-other-footnotes' => 'Other Footnotes',
     'author-info-contributions' => 'Author contributions',
-    'author-info-correspondence' => 'For corresponsdence',
+    'author-info-correspondence' => 'For correspondence',
     'author-info-additional-address' => 'Additional address',
     'author-info-competing-interest' => 'Competing interests',
     'author-info-funding' => 'Funding',


### PR DESCRIPTION
Fixes a typo in the "For correspondence" label - see http://jira.elifesciences.org:8080/browse/ELPP-807
