### PR TITLE
Opt out of access check when finding article version for an article reference

### DIFF
--- a/src/elife_profile/modules/custom/elife_article_reference/elife_article_reference.module
+++ b/src/elife_profile/modules/custom/elife_article_reference/elife_article_reference.module
@@ -161,7 +161,7 @@ function elife_article_reference_for_article_id(stdClass $article) {
 }
 
 function elife_article_reference_get_article_version($article_reference) {
-  $article = ElifeArticleVersion::getArticle($article_reference->field_elife_a_article_id[LANGUAGE_NONE][0]['value']);
+  $article = ElifeArticleVersion::fromIdentifier($article_reference->field_elife_a_article_id[LANGUAGE_NONE][0]['value'], TRUE, 'elife_article', 1, 'field_elife_a_article_id', TRUE);
   if ($article && !empty($article->field_elife_a_versions)) {
     $article_version = node_load($article->field_elife_a_versions[LANGUAGE_NONE][0]['target_id']);
     if ($article_version) {


### PR DESCRIPTION
We currently have a bug on the homepage where the access check for loading an article version for an article reference through a front matter item is causing it not to load. I haven't worked out what in the data is causing it to fail (on first glance everything appears to be as it should), but I believe this check to be unnecessary (as the article reference's publication status should be the same as the article/article version). Opting out of the check causes it to work.
