### PR TITLE
Bail out if the front matter/cover reference isn't found

### DIFF
--- a/src/elife_profile/modules/custom/elife_templates/plugins/content_types/elife_cover.inc
+++ b/src/elife_profile/modules/custom/elife_templates/plugins/content_types/elife_cover.inc
@@ -35,6 +35,10 @@ function elife_cover_plugin_render($subtype, $conf, $args, $context) {
     $reference = elife_article_reference_get_article_version($reference);
   }
 
+  if (empty($reference)) {
+    return NULL;
+  }
+
   $title_classes = array('headline-first__title_link');
   $attrs = array(
     'attributes' => array('class' => $title_classes),

--- a/src/elife_profile/modules/custom/elife_templates/plugins/content_types/elife_front_matter.inc
+++ b/src/elife_profile/modules/custom/elife_templates/plugins/content_types/elife_front_matter.inc
@@ -35,6 +35,10 @@ function elife_front_matter_plugin_render($subtype, $conf, $args, $context) {
     $reference = elife_article_reference_get_article_version($reference);
   }
 
+  if (empty($reference)) {
+    return NULL;
+  }
+
   $variables = array();
   $variables['display'] = ($conf['front_matter_type']) ? $conf['front_matter_type'] : 'regular';
 


### PR DESCRIPTION
The homepage is currently broken as a front matter item refers to something that isn't being loaded (and results in a `Trying to get property of non-object`). I'm not quite sure of the real cause (and hopefully #452 will solve it), but this is a quick way out.
