### PR TITLE
Ignore article/article version publication status on cron runs

### DIFF
--- a/src/elife_profile/modules/custom/elife_article/elife_article.module
+++ b/src/elife_profile/modules/custom/elife_article/elife_article.module
@@ -800,7 +800,7 @@ function elife_article_validator() {
  */
 function elife_article_version_source_xml_path($article_version) {
   if (!is_object($article_version)) {
-    $article_version = ElifeArticleVersion::fromIdentifier($article_version);
+    $article_version = ElifeArticleVersion::fromIdentifier($article_version, TRUE, 'elife_article_ver', 1, 'field_elife_a_article_version_id', TRUE);
   }
 
   $source_assets_base_path = variable_get('elife_article_source_assets_base_path');
@@ -1042,7 +1042,7 @@ function elife_article_version_to_dto_legacy(stdClass $entity) {
     return $cache[$entity->field_elife_a_article_version_id->value()];
   }
 
-  $entity_article = ElifeArticleVersion::getArticle($entity->field_elife_a_article_id->value(), TRUE);
+  $entity_article = ElifeArticleVersion::getArticle($entity->field_elife_a_article_id->value(), TRUE, TRUE);
   /* @var EntityDrupalWrapper $entity_article */
   $entity_article = entity_metadata_wrapper('node', $entity_article);
 

--- a/src/elife_profile/modules/custom/elife_article/src/ElifeArticleVersion.php
+++ b/src/elife_profile/modules/custom/elife_article/src/ElifeArticleVersion.php
@@ -155,11 +155,13 @@ class ElifeArticleVersion {
    *   Limit the number of articles returned.
    * @param string $id_field
    *   Field of the identifier.
+   * @param bool $access_opt_out
+   *   Set if we want to bypass content access controls.
    *
    * @return bool|mixed
    *   Details of the articles that match criteria.
    */
-  public static function fromId($article_id, $load = TRUE, $bundle = 'elife_article_ver', $conditions = array(), $limit = 0, $id_field = 'field_elife_a_article_id') {
+  public static function fromId($article_id, $load = TRUE, $bundle = 'elife_article_ver', $conditions = array(), $limit = 0, $id_field = 'field_elife_a_article_id', $access_opt_out = FALSE) {
     $id_query = new EntityFieldQueryExtraFields();
     $id_query->entityCondition('entity_type', 'node');
     $id_query->entityCondition('bundle', $bundle);
@@ -171,6 +173,11 @@ class ElifeArticleVersion {
     $id_query->addExtraField('field_elife_a_status', 'value', 'status');
     $id_query->addExtraField('field_elife_a_version', 'value', 'version');
     $id_query->addExtraField('field_elife_a_article_version_id', 'value', 'value');
+
+    // Need to retrieve unpublished content.
+    if ($access_opt_out) {
+      $id_query->addTag('DANGEROUS_ACCESS_CHECK_OPT_OUT');
+    }
 
     if (!empty($conditions)) {
       foreach ($conditions as $field => $value) {
@@ -308,12 +315,14 @@ class ElifeArticleVersion {
    *   Article Id.
    * @param bool $load
    *   Flag set to TRUE if we wish to load the article data.
+   * @param bool $access_opt_out
+   *   Set if we want to bypass content access controls.
    *
    * @return bool|mixed
    *   Details of the article collection entity.
    */
-  public static function getArticle($article_id, $load = TRUE) {
-    return self::fromIdentifier($article_id, $load, 'elife_article', 1, 'field_elife_a_article_id');
+  public static function getArticle($article_id, $load = TRUE, $access_opt_out = FALSE) {
+    return self::fromIdentifier($article_id, $load, 'elife_article', 1, 'field_elife_a_article_id', $access_opt_out);
   }
 
   /**

--- a/src/elife_profile/modules/custom/elife_article/src/ElifeXslMarkupService.php
+++ b/src/elife_profile/modules/custom/elife_article/src/ElifeXslMarkupService.php
@@ -226,7 +226,7 @@ class ElifeXslMarkupService extends ElifeMarkupService {
   }
 
   protected function processPlaceHolders($placeholders, $article_version_id, $query_id) {
-    $node = ElifeArticleVersion::fromId($article_version_id, TRUE, 'elife_article_ver', array(), 1, 'field_elife_a_article_version_id');
+    $node = ElifeArticleVersion::fromId($article_version_id, TRUE, 'elife_article_ver', array(), 1, 'field_elife_a_article_version_id', TRUE);
     $dto = elife_article_version_to_dto($node);
     $placeholders = array_unique($placeholders);
     $replacements = array();


### PR DESCRIPTION
#447 fixed the bug so that the article publication status was maintained correctly.

However, it turns out that `elife_article_cron()` didn't take access control into account, so it's now failing to populate the abstract and main text fields etc for any article (as it fails on an unpublished one and gets stuck).

(This is possibly similar to #451.)
