### PR TITLE
Add css class to enable handling of intra table separators in CSS

### DIFF
--- a/src/elife_profile/themes/custom/elife/css/global.css
+++ b/src/elife_profile/themes/custom/elife/css/global.css
@@ -1807,6 +1807,10 @@ div.highwire-markup .table-caption .table-caption,
   padding: 0;
 }
 
+.table-section-end {
+  border-bottom: 2px dashed rgb(0, 0, 15);
+}
+
 /* Supplementary Data */
 div.highwire-markup .supplementary-material > p,
 .fig-caption .supplementary-material .caption-title {


### PR DESCRIPTION
This update allows for a css class definition to control the dashed intra-table separator, rather than inline styles. An example of the page where this should be used is https://elifesciences.org/content/3/e02286/table5