### PR TITLE
Introduce digest survey call to action popup

### DIFF
--- a/src/elife_profile/modules/custom/elife_templates/css/elife-digest-survey-cta-popup.css
+++ b/src/elife_profile/modules/custom/elife_templates/css/elife-digest-survey-cta-popup.css
@@ -1,0 +1,91 @@
+.survey-cta-wrapper {
+  background-color: transparent;
+  margin: 0 auto;
+  position: fixed;
+  top: 100%;
+  transition: all 1s ease-in-out;
+  width: 100%;
+}
+
+.survey-cta-wrapper--shown {
+  transform: translateY(-10rem);
+}
+
+.survey-cta-wrapper--shown-by-fallback {
+  bottom: 50px;
+  bottom: 3.5rem;
+  top: auto;
+}
+
+.survey-cta {
+  background-color: #0188d1;
+  box-shadow: 1px 1px 2px rgba(0, 0, 15, 0.5);
+  color: #fff;
+  margin: 0 auto;
+  max-width: 800px;
+  max-width: 50rem;
+  position: relative;
+  z-index: 10;
+}
+
+.survey-cta:after {
+  clear: both;
+  content: "";
+  display: block;
+}
+
+.survey-cta__label {
+  float: left;
+  padding: 16px;
+  padding: 1rem;
+  max-width: 95%;
+}
+
+.survey-cta__link,
+.survey-cta__link:link,
+.survey-cta__link:visited {
+  background-color: #0188d1;
+  color: #fff;
+  font-family: "Avenir LT W01 35 Light", sans-serif;
+  font-weight: bolder;
+  text-decoration: none;
+  text-transform: uppercase;
+  padding-left: 16px;
+  padding-left: 1rem;
+}
+
+.survey-cta__links {
+  padding: 16px 16px 16px 40px;
+  padding: 1rem 1rem 1rem 2.5rem;
+  float: right;
+
+}
+
+.survey-cta__link:hover,
+.survey-cta__link:active {
+  text-decoration: none;
+}
+
+@media only all and (min-width:22.3125em) {
+
+  .survey-cta-wrapper--shown {
+    transform: translateY(-8.5rem);
+  }
+
+}
+
+@media only all and (min-width:41.0625em) {
+
+  .survey-cta-wrapper--shown {
+    transform: translateY(-7rem);
+  }
+
+}
+
+@media only all and (min-width: 50.125em) {
+
+  .survey-cta {
+    border-radius: 5px;
+  }
+
+}

--- a/src/elife_profile/modules/custom/elife_templates/elife_templates.module
+++ b/src/elife_profile/modules/custom/elife_templates/elife_templates.module
@@ -289,6 +289,7 @@ function elife_templates_article_page_markup_assets() {
   if (!$cache) {
     // Add js and css needed to help render the markup once it's in place.
     drupal_add_css(drupal_get_path('module', 'elife_templates') . '/css/elife-article-tables.css');
+    drupal_add_css(drupal_get_path('module', 'elife_templates') . '/css/elife-digest-survey-cta-popup.css');
 
     drupal_add_js(drupal_get_path('module', 'elife_templates') . '/js/elife_article_figures.js');
     drupal_add_js(drupal_get_path('module', 'elife_templates') . '/js/elife_article_tables.js');

--- a/src/elife_profile/modules/custom/elife_templates/js/elife_article_digest.js
+++ b/src/elife_profile/modules/custom/elife_templates/js/elife_article_digest.js
@@ -29,17 +29,39 @@
     },
 
     /**
+     * Generic cookie-setting function
+     *
+     * @param name {string} Name of the cookie to set
+     * @param value {string} Value to give the cookie
+     * @param [expires] {Date} Expiry date of cookie, defaults to 1 year hence if not provided
+     * @param [path] {string} Path of cookie scope, defaults to root if not provided
+     */
+    setCookie = function setCookie(name, value, expires, path) {
+      var cookie = name + '=' + value;
+      var expDateStr = (function (expires){
+        if (expires instanceof Date) {
+          return expires.toUTCString();
+        }
+        var exp = new Date();
+        exp.setTime(exp.getTime() + 1000 * 60 * 60 * 24 * 365);
+        return exp.toUTCString();
+      }(expires));
+      var _path = '' + path || '/';
+      // expires not max-age because IE8.
+      cookie += '; expires=' + expDateStr;
+      cookie += '; path=' + _path;
+      document.cookie = cookie;
+
+    },
+
+    /**
      * Sets a cookie recording the state of the digest.
      *
      * @param cookieData Data describing the cookie to set
      * @param digestState {String} "open" or "closed" (derived from cookieData)
      */
     setDigestCookie = function setDigestCookie(cookieData, digestState) {
-      var cookie = cookieData.name + '=' + cookieData.value[digestState];
-      // expires not max-age because IE8.
-      cookie += '; expires=' + cookieData.getDuration();
-      cookie += '; path=' + cookieData.path;
-      document.cookie = cookie;
+      setCookie(cookieData.name, cookieData.value[digestState], cookieData.getDuration(), cookieData.path);
     },
 
     /**


### PR DESCRIPTION
Introduces a popup on the article page, with a call to action to complete a survey about digests. The popup only displays when a digest read is recorded, and clicking yes or no sets a cookie preventing it displaying again.