### PR TITLE
Enable wrapping mid word

### DIFF
--- a/src/elife_profile/themes/custom/elife/color/preview.css
+++ b/src/elife_profile/themes/custom/elife/color/preview.css
@@ -20,6 +20,8 @@ html.js #preview {
   line-height: 1.5;
   overflow: hidden;
   word-wrap: break-word;
+  overflow-wrap: break-word;
+  word-break: break-all;
   margin-bottom: 10px;
 }
 #preview-header {

--- a/src/elife_profile/themes/custom/elife/css/global.css
+++ b/src/elife_profile/themes/custom/elife/css/global.css
@@ -1754,8 +1754,10 @@ div.highwire-markup .article div.section h4 {
 p {
   line-height: 1.75em; /* ~24px */
   margin-bottom: 10px;
-  /* Fix for very wide or unbreakable text. TODO: Target long unbreakable strings and use word-wrap:break-word;*/
-  word-wrap:break-word;
+  /* Fix for very wide or unbreakable text.*/
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  word-break: break-all;
 }
 
 .highwire-markup img.highwire-embed { max-width: 100%; }


### PR DESCRIPTION
Enables e.g. sequences to wrap when longer than the width of the container.

Useful when sequences are very long, e.g.:
<img width="731" alt="screenshot 2016-11-09 17 04 10" src="https://cloud.githubusercontent.com/assets/2893480/20147096/98d51e82-a69e-11e6-8118-9ec0e54eaf1b.png">

WIP because needs testing.