### PR TITLE
Revert wrapping mid word

### DIFF
--- a/src/elife_profile/themes/custom/elife/color/preview.css
+++ b/src/elife_profile/themes/custom/elife/color/preview.css
@@ -20,8 +20,6 @@ html.js #preview {
   line-height: 1.5;
   overflow: hidden;
   word-wrap: break-word;
-  overflow-wrap: break-word;
-  word-break: break-all;
   margin-bottom: 10px;
 }
 #preview-header {

--- a/src/elife_profile/themes/custom/elife/css/global.css
+++ b/src/elife_profile/themes/custom/elife/css/global.css
@@ -1754,10 +1754,8 @@ div.highwire-markup .article div.section h4 {
 p {
   line-height: 1.75em; /* ~24px */
   margin-bottom: 10px;
-  /* Fix for very wide or unbreakable text.*/
-  word-wrap: break-word;
-  overflow-wrap: break-word;
-  word-break: break-all;
+  /* Fix for very wide or unbreakable text. TODO: Target long unbreakable strings and use word-wrap:break-word;*/
+  word-wrap:break-word;
 }
 
 .highwire-markup img.highwire-embed { max-width: 100%; }


### PR DESCRIPTION
Without the ability to distinguish long sequences, the wrapping approach in #511  was too broad and caused non-sequence text to wrap. This PR reverses that.