### PR TITLE
Updated setting for hostname of elife-metrics project

### DIFF
--- a/src/settings.php
+++ b/src/settings.php
@@ -104,7 +104,7 @@ $conf['lagotto_services_url'] = 'http://alm.svr.elifesciences.org';
 $conf['lagotto_services_apikey'] = '5pVvShVqAJ9Ch3tFzori';
 
 // Setup elife_article_almvis.
-$conf['elife_article_almvis_metrics_url'] = 'https://master.metrics.elifesciences.org/api/v1/article/hw,ga/';
+$conf['elife_article_almvis_metrics_url'] = 'https://prod--metrics.elifesciences.org/api/v1/article/hw,ga/';
 $conf['elife_article_almvis_ga_switch_date'] = '2016-02-01';
 
 // See https://www.drupal.org/node/2009584.


### PR DESCRIPTION
I can't add a DNS as `master.metrics.elifesciences.org` cannot be served by our certificate.