### PR TITLE
Add HTTP request timeouts

### DIFF
--- a/src/elife_profile/modules/custom/elife_article/elife_article.module
+++ b/src/elife_profile/modules/custom/elife_article/elife_article.module
@@ -2881,7 +2881,7 @@ function elife_article_doi_to_glencoe_data_cache($doi) {
 
     if (empty($data)) {
       $request_uri = variable_get('elife_article_source_assets_glencoe_api') . $doi;
-      if ($result = drupal_http_request($request_uri)) {
+      if ($result = drupal_http_request($request_uri, ['timeout' => 3])) {
         $data = $result->data;
         cache_set($doi, $result->data, $cache_bin);
       }

--- a/src/elife_profile/modules/custom/elife_content_alerts/elife_content_alerts.module
+++ b/src/elife_profile/modules/custom/elife_content_alerts/elife_content_alerts.module
@@ -149,7 +149,7 @@ function _elife_content_alerts_output_array($type = 'content_alerts_vor', $args 
 
   $status = ($type == 'content_alerts_poa') ? 'POA' : 'VOR';
 
-  if ($http = drupal_http_request(url(sprintf('elife/content_alerts/%s/%s', $status, implode('--', [$args['start'], $args['end']])), ['absolute' => TRUE]))) {
+  if ($http = drupal_http_request(url(sprintf('elife/content_alerts/%s/%s', $status, implode('--', [$args['start'], $args['end']])), ['absolute' => TRUE]), ['timeout' => 3])) {
     libxml_use_internal_errors(TRUE);
     $doc = new DOMDocument();
     $doc->loadHTML($http->data);

--- a/src/elife_profile/modules/custom/elife_http_client/elife_http_client.module
+++ b/src/elife_profile/modules/custom/elife_http_client/elife_http_client.module
@@ -27,7 +27,7 @@ function _elife_http_client_guzzle() {
   $client = &drupal_static(__FUNCTION__);
 
   if (!isset($client)) {
-    $guzzle = new Guzzle();
+    $guzzle = new Guzzle(['defaults' => ['timeout' => 3]]);
     $client = new Guzzle5HttpClient($guzzle);
   }
 

--- a/src/elife_profile/modules/custom/elife_resources/elife_resources.class.inc
+++ b/src/elife_profile/modules/custom/elife_resources/elife_resources.class.inc
@@ -76,7 +76,7 @@ class elifeResources {
       return $response;
     }
     else {
-      $response = drupal_http_request(self::RESOURCES_API . $this->query);
+      $response = drupal_http_request(self::RESOURCES_API . $this->query, ['timeout' => 3]);
       $this->setCache($response);
     }
     return $response;


### PR DESCRIPTION
Follows 8d2596eddac02f3360bfdf74c97732997ee07fe9 and #529. This adds (sensible) timeouts to remaining HTTP requests. (I don't think some of these handle errors gracefully, but they should now break rather than hang.) Given there are (at least) 4 different mechanisms* at making requests, I might be missing some more - what New Relic reports appears to be accounted for, but can you confirm @nlisgo?

\* `drupal_http_request()`, `fopen()`, `file_get_contents()` and Guzzle.