### PR TITLE
Introduce latest markup

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -242,12 +242,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/elife-ingest-xsl.git",
-                "reference": "d4b8ffa70ca77b3e29c712a5ab9aef76f875cbf8"
+                "reference": "3300c9d8068ac7771d9e3311b3f3d397426927c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/elife-ingest-xsl/zipball/d4b8ffa70ca77b3e29c712a5ab9aef76f875cbf8",
-                "reference": "d4b8ffa70ca77b3e29c712a5ab9aef76f875cbf8",
+                "url": "https://api.github.com/repos/elifesciences/elife-ingest-xsl/zipball/3300c9d8068ac7771d9e3311b3f3d397426927c3",
+                "reference": "3300c9d8068ac7771d9e3311b3f3d397426927c3",
                 "shasum": ""
             },
             "require": {
@@ -287,7 +287,7 @@
             "support": {
                 "source": "https://github.com/elifesciences/elife-ingest-xsl/tree/master"
             },
-            "time": "2016-12-16 12:00:14"
+            "time": "2017-03-01 12:41:53"
         },
         {
             "name": "elifesciences/elife-eif-schema",

--- a/src/elife_profile/elife_profile.install
+++ b/src/elife_profile/elife_profile.install
@@ -306,3 +306,10 @@ function elife_profile_update_7129() {
 function elife_profile_update_7130() {
   _elife_article_markup_cache_clear_all();
 }
+
+/**
+ * Clear the markup cache.
+ */
+function elife_profile_update_7131() {
+  _elife_article_markup_cache_clear_all();
+}


### PR DESCRIPTION
Any `<p>` element with a class `first-child` will now just be `<p>`.

Here is the commit to elife-ingest-xsl commit which shows some instances of where the change to the markup can be found: https://github.com/elifesciences/elife-ingest-xsl/commit/8749d1ad315258d792bfcb0d1c77e89c74b0aa5f

The expectation is that there is no change for the end user as there is no css or javascript that targets an element by using that class.