### PR TITLE
Enable the uuid module

### DIFF
--- a/src/elife_profile/elife_profile.info
+++ b/src/elife_profile/elife_profile.info
@@ -108,6 +108,7 @@ dependencies[] = taxonomy_access_fix
 dependencies[] = token
 dependencies[] = transliteration
 dependencies[] = unicode
+dependencies[] = uuid
 dependencies[] = view_unpublished
 dependencies[] = views
 dependencies[] = views_bulk_operations

--- a/src/elife_profile/elife_profile.install
+++ b/src/elife_profile/elife_profile.install
@@ -320,3 +320,10 @@ function elife_profile_update_7131() {
 function elife_profile_update_7132() {
   _elife_article_markup_cache_clear_all();
 }
+
+/**
+ * Enable uuid.
+ */
+function elife_profile_update_7133() {
+  module_enable(['uuid'], FALSE);
+}

--- a/src/elife_profile/elife_profile.make.yml
+++ b/src/elife_profile/elife_profile.make.yml
@@ -224,6 +224,8 @@ projects:
     version: '1.0'
     patch:
       - 'https://www.drupal.org/files/issues/unicode-load-decode-2711787-3.patch'
+  uuid:
+    version: '1.0-beta2'
   view_unpublished:
     version: '1.2'
   views:


### PR DESCRIPTION
This will aid us in persisting identifiers for elife 2.0