### PR TITLE
Fixing broken link on the About page

### DIFF
--- a/src/elife_profile/modules/custom/elife_about/templates/elife_about.tpl.php
+++ b/src/elife_profile/modules/custom/elife_about/templates/elife_about.tpl.php
@@ -196,5 +196,5 @@
 <!-- Submit -->
 <section class="about-section about-submit-cta">
   <h2 class="about-heading">Working on something interesting?</h2>
-  <a href="https://crm.elifesciences.org/crm/civicrm/event/register?reset=1&id=14" class="about-submit-cta_link">Let us know now</a>
+  <a href="mailto:staff@elifesciences.org?Subject=Presubmission%20enquiry">Let us know now</a>
 </section> <!-- /.about-submit-cta -->

--- a/src/elife_profile/modules/custom/elife_about/templates/elife_about.tpl.php
+++ b/src/elife_profile/modules/custom/elife_about/templates/elife_about.tpl.php
@@ -196,5 +196,5 @@
 <!-- Submit -->
 <section class="about-section about-submit-cta">
   <h2 class="about-heading">Working on something interesting?</h2>
-  <a href="mailto:staff@elifesciences.org?Subject=Presubmission%20enquiry">Let us know now</a>
+  <a href="mailto:staff@elifesciences.org?Subject=Presubmission%20enquiry" class="about-submit-cta_link">Let us know now</a>
 </section> <!-- /.about-submit-cta -->


### PR DESCRIPTION
Marcomms deleted the Civi form behind the "Let us know" button, so this puts in place a replacement e-mail address.